### PR TITLE
🐛 fix: resolve TypeScript strict index and biome format errors in tests

### DIFF
--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -1,1 +1,1 @@
-console.log('Hello from the runner package!');
+console.log("Hello from the runner package!");

--- a/packages/runtime/src/message.test.ts
+++ b/packages/runtime/src/message.test.ts
@@ -58,7 +58,7 @@ test("send writes valid JSON to the inbox", async () => {
   expect(files).toHaveLength(1);
   expect(files[0]).toEndWith(".msg");
 
-  const raw = await Bun.file(join(inboxDir, files[0])).json();
+  const raw = await Bun.file(join(inboxDir, files[0] as string)).json();
   expect(raw).toEqual(msg);
 });
 
@@ -86,7 +86,7 @@ test("read parses a valid message file", async () => {
   const inboxDir = join(root, AGENT, "inbox");
   const files = await list(inboxDir);
 
-  const parsed = await read(inboxDir, files[0]);
+  const parsed = await read(inboxDir, files[0] as string);
   expect(parsed).toEqual(msg);
 });
 
@@ -103,7 +103,7 @@ test("consume reads and moves message to .processed", async () => {
   const msg = await send(root, AGENT, "sender", "consume test");
   const inboxDir = join(root, AGENT, "inbox");
   const files = await list(inboxDir);
-  const filename = files[0];
+  const filename = files[0] as string;
 
   const result = await consume(inboxDir, filename);
   expect(result).toEqual(msg);

--- a/packages/runtime/src/process-table.test.ts
+++ b/packages/runtime/src/process-table.test.ts
@@ -95,9 +95,9 @@ test("state round-trip through entries", () => {
   agent.startedAt = "2026-03-25T12:00:00.000Z";
 
   const [entry] = table.entries();
-  expect(entry.pid).toBe(123);
-  expect(entry.status).toBe("running");
-  expect(entry.model).toBe("anthropic/claude-sonnet-4-6");
-  expect(entry.startedAt).toBe("2026-03-25T12:00:00.000Z");
-  expect(entry.stoppedAt).toBeNull();
+  expect(entry?.pid).toBe(123);
+  expect(entry?.status).toBe("running");
+  expect(entry?.model).toBe("anthropic/claude-sonnet-4-6");
+  expect(entry?.startedAt).toBe("2026-03-25T12:00:00.000Z");
+  expect(entry?.stoppedAt).toBeNull();
 });


### PR DESCRIPTION
## Summary
- Replace non-null assertions with `as string` casts and optional chaining to satisfy both biome and TypeScript strict mode
- Fix quote style in runner index.ts

## Test plan
- [x] `bun run check` passes
- [x] `bun run build` passes
- [x] `bun test` — all 61 tests pass