### PR TITLE
🔧 chore: add shared pre-commit hook for lint, build, and test

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "🔍 Lint (staged files)..."
+bun biome check --staged
+
+echo "🔨 Build..."
+bun run build
+
+echo "🧪 Test..."
+bun test

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "build": "bun run --filter './packages/*' build",
     "build:pkg": "bun tools/build-publish-package.ts packages/runtime && bun tools/build-publish-package.ts packages/runner",
+    "prepare": "git config core.hooksPath .githooks",
     "check": "biome check .",
     "fix": "biome check --write .",
     "format": "biome format --write .",


### PR DESCRIPTION
## Summary
- Add `.githooks/pre-commit` that runs biome lint (staged files only), build, and tests
- Add `prepare` script to `package.json` to auto-configure `core.hooksPath` after `bun install`
- Zero dependencies, works cross-platform via Git's built-in `core.hooksPath`

## Test plan
- [x] Hook ran successfully during this commit
- [x] `bun run check`, `bun run build`, `bun test` all pass