### PR TITLE
📝 docs: add security policy, issue templates, and PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,44 @@
+name: Bug Report
+description: Report a bug in loom
+labels: ["bug"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What happened? What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps to reproduce the issue.
+      placeholder: |
+        1. Run `loom spawn ...`
+        2. Send a message with `loom send ...`
+        3. See error in `agents/<name>/crashes/`
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: Output of `loom --version` or package version
+    validations:
+      required: true
+  - type: dropdown
+    id: os
+    attributes:
+      label: OS
+      options:
+        - Linux
+        - macOS
+        - Windows
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Logs, agent directory contents, screenshots, etc. Redact any secrets.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,32 @@
+name: Feature Request
+description: Suggest a new feature or improvement
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What problem does this solve? Why is it needed?
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: How should this work? Be as specific as possible.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any other approaches you've thought about.
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Scope
+      description: Does this belong in core or as a plugin?
+      options:
+        - Core (runtime/runner)
+        - Plugin (separate package)
+        - Not sure

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,8 @@
+## Summary
+<!-- What does this PR do and why? -->
+
+## Test plan
+<!-- How was this tested? -->
+- [ ] `bun run check` passes
+- [ ] `bun run build` passes
+- [ ] `bun test` passes

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,34 @@
+# Security Policy
+
+## Supported versions
+
+Only the latest release is supported with security updates.
+
+| Version | Supported |
+| ------- | --------- |
+| latest  | Yes       |
+| < latest | No       |
+
+## Reporting a vulnerability
+
+**Please do not open a public issue for security vulnerabilities.**
+
+Instead, report vulnerabilities privately via [GitHub Security Advisories](https://github.com/lorenzh/loom/security/advisories/new).
+
+Include:
+- Description of the vulnerability
+- Steps to reproduce
+- Affected versions
+- Potential impact
+
+You should receive an acknowledgement within 48 hours. Once confirmed, a fix will be prioritised and released as soon as possible.
+
+## Scope
+
+The following are in scope:
+- `@losoft/loom-runtime` — process table, inbox/outbox, message handling
+- `@losoft/loom-runner` — agent runner, provider routing
+
+Out of scope:
+- Third-party model providers (Ollama, OpenAI, Anthropic APIs)
+- Issues in dependencies — please report those upstream


### PR DESCRIPTION
## Summary
- Add `SECURITY.md` with private vulnerability reporting via GitHub Security Advisories
- Add issue templates: bug report (structured form) and feature request (with core/plugin scope)
- Add PR template with summary and test plan checklist

## Test plan
- [ ] Verify templates appear when creating new issues/PRs on GitHub