### PR TITLE
📝 docs: move draft ADRs to drafts folder and remove numbers

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 echo "🔍 Lint (staged files)..."
-bun biome check --staged
+bun biome check --staged --no-errors-on-unmatched
 
 echo "🔨 Build..."
 bun run build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,8 @@ packages/
   runtime/   → @losoft/loom-runtime  (zero-dependency core primitives)
   runner/    → @losoft/loom-runner   (LLM provider abstraction, depends on runtime)
 tools/       → build and publish scripts
-docs/adrs/   → architecture decision records (ADR-001 through ADR-010)
+docs/adrs/         → accepted architecture decision records (numbered)
+docs/adrs/drafts/  → draft ADR proposals (unnumbered)
 .githooks/   → shared git hooks
 ```
 
@@ -127,12 +128,20 @@ A PR template is provided automatically. Before requesting review, ensure the ch
 
 ## ADRs
 
-Significant design decisions need an ADR in `docs/adrs/`. Use this template:
+Significant design decisions are tracked as architecture decision records (ADRs).
+
+### Workflow
+
+1. **Propose** — create a new file in `docs/adrs/drafts/` with a descriptive slug (no number). Set its status to `Draft`.
+2. **Review** — the draft is discussed in a PR. Iterate until accepted.
+3. **Accept** — once approved, the file is assigned the next sequential ADR number, renamed to `docs/adrs/ADR-{NNN}-{slug}.md`, and its status is set to `Accepted`.
+
+### Template
 
 ```md
-# ADR-XXX: Title
+# Title
 
-**Status:** Draft | Accepted | Superseded
+**Status:** Draft
 **Date:** YYYY-MM-DD
 
 ## Context
@@ -148,7 +157,7 @@ What are the tradeoffs?
 What did we reject and why?
 ```
 
-ADR numbers are sequential. There are currently 10 ADRs (ADR-001 through ADR-010) in `docs/adrs/`. Check existing ADRs before numbering yours.
+Accepted ADRs (ADR-001 through ADR-004) live in `docs/adrs/`. Draft proposals live in `docs/adrs/drafts/`.
 
 ## Code style
 

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ loom spawn my-agent --model openrouter/anthropic/claude-3.5-sonnet
 | `openai/` | OpenAI | `OPENAI_API_KEY`, `OPENAI_BASE_URL` |
 | `openrouter/` | OpenRouter | `OPENROUTER_API_KEY` |
 
-See [`docs/adrs/ADR-007-model-routing.md`](docs/adrs/ADR-007-model-routing.md) for the full model routing spec.
+See [`docs/adrs/drafts/model-routing.md`](docs/adrs/drafts/model-routing.md) for the full model routing spec.
 
 ---
 
@@ -215,7 +215,9 @@ they just won't be restarted until the supervisor comes back.
 
 ## Design decisions
 
-Architecture decision records live in [`docs/adrs/`](docs/adrs/):
+Architecture decision records live in [`docs/adrs/`](docs/adrs/). Accepted ADRs are numbered; drafts live in [`docs/adrs/drafts/`](docs/adrs/drafts/) and receive a number once approved.
+
+### Accepted
 
 | ADR | Title |
 |-----|-------|
@@ -223,12 +225,17 @@ Architecture decision records live in [`docs/adrs/`](docs/adrs/):
 | [ADR-002](docs/adrs/ADR-002-filesystem-as-process-table.md) | Filesystem as process table |
 | [ADR-003](docs/adrs/ADR-003-inbox-watcher-polling.md) | Inbox watcher via polling |
 | [ADR-004](docs/adrs/ADR-004-supervisor-and-restart-policy.md) | Supervisor and restart policy |
-| [ADR-005](docs/adrs/ADR-005-loom-yml-weave-config.md) | loom.yml weave config format |
-| [ADR-006](docs/adrs/ADR-006-plugin-model.md) | Plugin and extension model |
-| [ADR-007](docs/adrs/ADR-007-model-routing.md) | Model routing and provider abstraction |
-| [ADR-008](docs/adrs/ADR-008-filesystem-state-store.md) | Filesystem as state store |
-| [ADR-009](docs/adrs/ADR-009-plugin-protocol.md) | Plugin protocol — tools as executables |
-| [ADR-010](docs/adrs/ADR-010-pipe-engine.md) | Pipe engine — outbox-to-inbox forwarding |
+
+### Drafts
+
+| Proposal | Title |
+|----------|-------|
+| [loom-yml-weave-config](docs/adrs/drafts/loom-yml-weave-config.md) | loom.yml weave config format |
+| [plugin-model](docs/adrs/drafts/plugin-model.md) | Plugin and extension model |
+| [model-routing](docs/adrs/drafts/model-routing.md) | Model routing and provider abstraction |
+| [filesystem-state-store](docs/adrs/drafts/filesystem-state-store.md) | Filesystem as state store |
+| [plugin-protocol](docs/adrs/drafts/plugin-protocol.md) | Plugin protocol — tools as executables |
+| [pipe-engine](docs/adrs/drafts/pipe-engine.md) | Pipe engine — outbox-to-inbox forwarding |
 
 ---
 

--- a/docs/adrs/drafts/filesystem-state-store.md
+++ b/docs/adrs/drafts/filesystem-state-store.md
@@ -1,4 +1,4 @@
-# ADR-008: Filesystem as State Store
+# Filesystem as State Store
 
 **Status:** Draft
 **Date:** 2026-03-26

--- a/docs/adrs/drafts/loom-yml-weave-config.md
+++ b/docs/adrs/drafts/loom-yml-weave-config.md
@@ -1,4 +1,4 @@
-# ADR-005: loom.yml — declarative weave configuration
+# loom.yml — declarative weave configuration
 
 **Status:** Draft
 **Date:** 2026-03-25

--- a/docs/adrs/drafts/model-routing.md
+++ b/docs/adrs/drafts/model-routing.md
@@ -1,4 +1,4 @@
-# ADR-007: Model routing and provider abstraction
+# Model routing and provider abstraction
 
 **Status:** Draft
 **Date:** 2026-03-25

--- a/docs/adrs/drafts/pipe-engine.md
+++ b/docs/adrs/drafts/pipe-engine.md
@@ -1,4 +1,4 @@
-# ADR-010: Pipe engine — wiring agent outboxes to inboxes
+# Pipe engine — wiring agent outboxes to inboxes
 
 **Status:** Draft
 **Date:** 2026-03-26

--- a/docs/adrs/drafts/plugin-model.md
+++ b/docs/adrs/drafts/plugin-model.md
@@ -1,4 +1,4 @@
-# ADR-006: Plugin and extension model
+# Plugin and extension model
 
 **Status:** Draft
 **Date:** 2026-03-25

--- a/docs/adrs/drafts/plugin-protocol.md
+++ b/docs/adrs/drafts/plugin-protocol.md
@@ -1,4 +1,4 @@
-# ADR-009: Plugin Protocol — Tools as Executables
+# Plugin Protocol — Tools as Executables
 
 **Status:** Draft
 **Date:** 2026-03-26


### PR DESCRIPTION
## Summary

- Move draft ADRs (005–010) from `docs/adrs/` to `docs/adrs/drafts/`, stripping ADR numbers from filenames and headings — numbers are assigned only when a proposal is accepted
- Update README.md to split the design decisions table into Accepted and Drafts sections
- Update CONTRIBUTING.md with the new propose → review → accept ADR workflow
- Fix pre-commit hook failing on markdown-only commits (`--no-errors-on-unmatched`)

## Test plan

- [ ] Verify `docs/adrs/` contains only ADR-001 through ADR-004
- [ ] Verify `docs/adrs/drafts/` contains the 6 unnumbered draft files
- [ ] Confirm all links in README.md and CONTRIBUTING.md resolve correctly