### PR TITLE
✨ feat: scaffold CLI and Supervisor packages

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,6 +12,17 @@
         "typescript": "^5",
       },
     },
+    "packages/cli": {
+      "name": "@losoft/loom-cli",
+      "dependencies": {
+        "@losoft/loom-runner": "workspace:*",
+        "@losoft/loom-runtime": "workspace:*",
+        "@losoft/loom-supervisor": "workspace:*",
+      },
+      "peerDependencies": {
+        "typescript": "^5",
+      },
+    },
     "packages/runner": {
       "name": "@losoft/loom-runner",
       "dependencies": {
@@ -23,6 +34,16 @@
     },
     "packages/runtime": {
       "name": "@losoft/loom-runtime",
+      "peerDependencies": {
+        "typescript": "^5",
+      },
+    },
+    "packages/supervisor": {
+      "name": "@losoft/loom-supervisor",
+      "dependencies": {
+        "@losoft/loom-runner": "workspace:*",
+        "@losoft/loom-runtime": "workspace:*",
+      },
       "peerDependencies": {
         "typescript": "^5",
       },
@@ -47,9 +68,13 @@
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.9", "", { "os": "win32", "cpu": "x64" }, "sha512-NS4g/2G9SoQ4ktKtz31pvyc/rmgzlcIDCGU/zWbmHJAqx6gcRj2gj5Q/guXhoWTzCUaQZDIqiCQXHS7BcGYc0w=="],
 
+    "@losoft/loom-cli": ["@losoft/loom-cli@workspace:packages/cli"],
+
     "@losoft/loom-runner": ["@losoft/loom-runner@workspace:packages/runner"],
 
     "@losoft/loom-runtime": ["@losoft/loom-runtime@workspace:packages/runtime"],
+
+    "@losoft/loom-supervisor": ["@losoft/loom-supervisor@workspace:packages/supervisor"],
 
     "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   ],
   "scripts": {
     "build": "bun run --filter './packages/*' build",
-    "build:pkg": "bun tools/build-publish-package.ts packages/runtime && bun tools/build-publish-package.ts packages/runner",
+    "build:pkg": "bun tools/build-publish-package.ts packages/runtime && bun tools/build-publish-package.ts packages/runner && bun tools/build-publish-package.ts packages/supervisor && bun tools/build-publish-package.ts packages/cli",
     "prepare": "git config core.hooksPath .githooks",
     "check": "biome check .",
     "fix": "biome check --write .",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@losoft/loom-cli",
+  "description": "CLI for loom — start, stop, inspect, and manage agents",
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "build:bun": "bun build ./src/index.ts --outdir ./dist/bun",
+    "build:node": "bun build ./src/index.ts --outdir ./dist/node --format esm --target node --packages external",
+    "build:types": "tsc --emitDeclarationOnly --outDir dist",
+    "clean": "rm -rf dist",
+    "build": "bun run clean && bun run build:bun && bun run build:node && bun run build:types"
+  },
+  "dependencies": {
+    "@losoft/loom-runtime": "workspace:*",
+    "@losoft/loom-runner": "workspace:*",
+    "@losoft/loom-supervisor": "workspace:*"
+  },
+  "peerDependencies": {
+    "typescript": "^5"
+  }
+}

--- a/packages/cli/package.pub.json
+++ b/packages/cli/package.pub.json
@@ -1,0 +1,13 @@
+{
+  "bin": {
+    "loom": "./bun/index.js"
+  },
+  "exports": {
+    ".": {
+      "bun": "./bun/index.js",
+      "node": "./node/index.js",
+      "import": "./node/index.js",
+      "types": "./index.d.ts"
+    }
+  }
+}

--- a/packages/cli/src/commands/down.ts
+++ b/packages/cli/src/commands/down.ts
@@ -1,0 +1,4 @@
+/** Stop all agents from a weave. */
+export async function down(_args: string[], _loomHome: string): Promise<void> {
+  console.log("loom down — not yet implemented");
+}

--- a/packages/cli/src/commands/logs.ts
+++ b/packages/cli/src/commands/logs.ts
@@ -1,0 +1,4 @@
+/** View agent logs. */
+export async function logs(_args: string[], _loomHome: string): Promise<void> {
+  console.log("loom logs — not yet implemented");
+}

--- a/packages/cli/src/commands/ps.ts
+++ b/packages/cli/src/commands/ps.ts
@@ -1,0 +1,4 @@
+/** List running agents. */
+export async function ps(_args: string[], _loomHome: string): Promise<void> {
+  console.log("loom ps — not yet implemented");
+}

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -1,0 +1,4 @@
+/** Start a single agent (foreground or detached). */
+export async function run(_args: string[], _loomHome: string): Promise<void> {
+  console.log("loom run — not yet implemented");
+}

--- a/packages/cli/src/commands/send.ts
+++ b/packages/cli/src/commands/send.ts
@@ -1,0 +1,4 @@
+/** Send a message to an agent's inbox. */
+export async function send(_args: string[], _loomHome: string): Promise<void> {
+  console.log("loom send — not yet implemented");
+}

--- a/packages/cli/src/commands/stop.ts
+++ b/packages/cli/src/commands/stop.ts
@@ -1,0 +1,4 @@
+/** Stop a specific agent. */
+export async function stop(_args: string[], _loomHome: string): Promise<void> {
+  console.log("loom stop — not yet implemented");
+}

--- a/packages/cli/src/commands/up.ts
+++ b/packages/cli/src/commands/up.ts
@@ -1,0 +1,4 @@
+/** Start a weave of agents from loom.yml. */
+export async function up(_args: string[], _loomHome: string): Promise<void> {
+  console.log("loom up — not yet implemented");
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,0 +1,9 @@
+#!/usr/bin/env bun
+
+export { down } from "./commands/down";
+export { logs } from "./commands/logs";
+export { ps } from "./commands/ps";
+export { run } from "./commands/run";
+export { send } from "./commands/send";
+export { stop } from "./commands/stop";
+export { up } from "./commands/up";

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -1,0 +1,61 @@
+#!/usr/bin/env bun
+
+import { down } from "./commands/down";
+import { logs } from "./commands/logs";
+import { ps } from "./commands/ps";
+import { run } from "./commands/run";
+import { send } from "./commands/send";
+import { stop } from "./commands/stop";
+import { up } from "./commands/up";
+
+/** Resolve $LOOM_HOME, defaulting to ~/.loom. */
+function resolveLoomHome(): string {
+  return process.env.LOOM_HOME ?? `${process.env.HOME}/.loom`;
+}
+
+const commands: Record<string, (args: string[], loomHome: string) => Promise<void>> = {
+  run,
+  ps,
+  stop,
+  up,
+  down,
+  send,
+  logs,
+};
+
+async function main(): Promise<void> {
+  const [command, ...args] = process.argv.slice(2);
+
+  if (!command || command === "--help" || command === "-h") {
+    printUsage();
+    process.exit(0);
+  }
+
+  const handler = commands[command];
+  if (!handler) {
+    console.error(`Unknown command: ${command}`);
+    printUsage();
+    process.exit(1);
+  }
+
+  const loomHome = resolveLoomHome();
+  await handler(args, loomHome);
+}
+
+function printUsage(): void {
+  console.log(`Usage: loom <command> [options]
+
+Commands:
+  run    Start a single agent
+  up     Start a weave of agents from loom.yml
+  ps     List running agents
+  stop   Stop a specific agent
+  down   Stop all agents from a weave
+  send   Send a message to an agent's inbox
+  logs   View agent logs`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/supervisor/package.json
+++ b/packages/supervisor/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@losoft/loom-supervisor",
+  "description": "Supervisor — process manager for loom agents with restart policies and crash tracking",
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "build:bun": "bun build ./src/index.ts --outdir ./dist/bun",
+    "build:node": "bun build ./src/index.ts --outdir ./dist/node --format esm --target node --packages external",
+    "build:types": "tsc --emitDeclarationOnly --outDir dist",
+    "clean": "rm -rf dist",
+    "build": "bun run clean && bun run build:bun && bun run build:node && bun run build:types"
+  },
+  "dependencies": {
+    "@losoft/loom-runtime": "workspace:*",
+    "@losoft/loom-runner": "workspace:*"
+  },
+  "peerDependencies": {
+    "typescript": "^5"
+  }
+}

--- a/packages/supervisor/package.pub.json
+++ b/packages/supervisor/package.pub.json
@@ -1,0 +1,10 @@
+{
+  "exports": {
+    ".": {
+      "bun": "./bun/index.js",
+      "node": "./node/index.js",
+      "import": "./node/index.js",
+      "types": "./index.d.ts"
+    }
+  }
+}

--- a/packages/supervisor/src/index.ts
+++ b/packages/supervisor/src/index.ts
@@ -1,0 +1,2 @@
+export type { CrashRecord, RestartPolicy } from "./restart";
+export { Supervisor, type SupervisorOptions } from "./supervisor";

--- a/packages/supervisor/src/restart.ts
+++ b/packages/supervisor/src/restart.ts
@@ -1,0 +1,42 @@
+/** Restart policy for an agent. */
+export type RestartPolicy = "always" | "on-failure" | "never";
+
+/** Record of a single agent crash, persisted to the crashes/ directory. */
+export interface CrashRecord {
+  ts: string;
+  exitCode: number | null;
+  signal: string | null;
+  restartCount: number;
+  nextRestartAt: string | null;
+}
+
+export interface BackoffOptions {
+  baseDelayMs: number;
+  maxBackoffMs: number;
+  maxRestarts: number;
+  resetWindowMs: number;
+}
+
+const DEFAULT_BACKOFF: BackoffOptions = {
+  baseDelayMs: 1_000,
+  maxBackoffMs: 300_000,
+  maxRestarts: 10,
+  resetWindowMs: 3_600_000,
+};
+
+/** Compute the next restart delay using exponential backoff with jitter. */
+export function computeBackoff(restartCount: number, opts: Partial<BackoffOptions> = {}): number {
+  const { baseDelayMs, maxBackoffMs } = { ...DEFAULT_BACKOFF, ...opts };
+  const delay = Math.min(baseDelayMs * 2 ** restartCount, maxBackoffMs);
+  const jitter = Math.random() * 500;
+  return delay + jitter;
+}
+
+/** Check whether the agent has exceeded its restart limit. */
+export function isMaxRestartsExceeded(
+  restartCount: number,
+  opts: Partial<BackoffOptions> = {},
+): boolean {
+  const { maxRestarts } = { ...DEFAULT_BACKOFF, ...opts };
+  return restartCount >= maxRestarts;
+}

--- a/packages/supervisor/src/supervisor.ts
+++ b/packages/supervisor/src/supervisor.ts
@@ -1,0 +1,88 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import type { RestartPolicy } from "./restart";
+
+export interface SupervisorOptions {
+  /** Root directory for loom state ($LOOM_HOME). */
+  loomHome: string;
+  /** Scan interval in milliseconds (default: 5000). */
+  scanIntervalMs?: number;
+}
+
+/** Managed agent entry tracked by the supervisor. */
+interface ManagedAgent {
+  name: string;
+  process: ReturnType<typeof Bun.spawn> | null;
+  restartCount: number;
+  restartPolicy: RestartPolicy;
+}
+
+/**
+ * Process manager for loom agents.
+ *
+ * Spawns runners, detects crashes, and restarts with backoff.
+ * Writes its PID to $LOOM_HOME/supervisor.pid.
+ */
+export class Supervisor {
+  readonly loomHome: string;
+  private scanIntervalMs: number;
+  private agents = new Map<string, ManagedAgent>();
+  private scanTimer: ReturnType<typeof setInterval> | null = null;
+  private running = false;
+
+  constructor(opts: SupervisorOptions) {
+    this.loomHome = opts.loomHome;
+    this.scanIntervalMs = opts.scanIntervalMs ?? 5_000;
+  }
+
+  /** Start the supervisor and begin scanning for agents. */
+  start(): void {
+    if (this.running) return;
+    this.running = true;
+
+    const pidPath = join(this.loomHome, "supervisor.pid");
+    writeFileSync(pidPath, `${process.pid}\n`, "utf8");
+
+    this.scan();
+    this.scanTimer = setInterval(() => this.scan(), this.scanIntervalMs);
+
+    process.on("SIGHUP", () => this.scan());
+  }
+
+  /** Stop the supervisor and all managed agents. */
+  stop(): void {
+    if (!this.running) return;
+    this.running = false;
+
+    if (this.scanTimer) {
+      clearInterval(this.scanTimer);
+      this.scanTimer = null;
+    }
+
+    for (const agent of this.agents.values()) {
+      agent.process?.kill();
+    }
+    this.agents.clear();
+
+    const pidPath = join(this.loomHome, "supervisor.pid");
+    if (existsSync(pidPath)) {
+      const { unlinkSync } = require("node:fs");
+      unlinkSync(pidPath);
+    }
+  }
+
+  /** Scan agent directories for status changes. */
+  private scan(): void {
+    // Scan implementation — reads $LOOM_HOME/agents/*/status
+    // and spawns/stops runners as needed.
+  }
+
+  /** Read the supervisor PID from the filesystem, or null if not running. */
+  static readPid(loomHome: string): number | null {
+    const pidPath = join(loomHome, "supervisor.pid");
+    if (!existsSync(pidPath)) return null;
+    const raw = readFileSync(pidPath, "utf8").trim();
+    const pid = Number.parseInt(raw, 10);
+    return Number.isNaN(pid) ? null : pid;
+  }
+}

--- a/packages/supervisor/tsconfig.json
+++ b/packages/supervisor/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary
- Scaffold `@losoft/loom-cli` with entrypoint, arg parsing, and command stubs (`run`, `ps`, `stop`, `up`, `down`, `send`, `logs`) per ADR-006
- Scaffold `@losoft/loom-supervisor` with `Supervisor` class, PID file management, restart policy types, and backoff utilities per ADR-004
- Both packages follow existing conventions: workspace deps, dual bun/node builds, `package.pub.json`, extended tsconfig
- Updated root `build:pkg` script to include new packages

## Test plan
- [x] `bun run build` succeeds for all 4 packages
- [x] `bun run check` passes with no errors
- [x] `bun test` — all 61 existing tests pass

Closes #41