### PR TITLE
✨ feat(runtime): add three-phase message lifecycle with claim/acknowledge

### DIFF
--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1,5 +1,5 @@
 export { type AgentEntry, AgentProcess, type AgentStatus } from "./agent-process";
 export { InboxRouter, type InboxRouterOptions } from "./inbox-router";
 export { InboxWatcher, type InboxWatcherOptions } from "./inbox-watcher";
-export { consume, list, type Message, quarantine, read, send } from "./message";
+export { acknowledge, claim, consume, list, type Message, quarantine, read, send } from "./message";
 export { ProcessTable } from "./process-table";

--- a/packages/runtime/src/message.test.ts
+++ b/packages/runtime/src/message.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, expect, test } from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { consume, isMessage, list, quarantine, read, send } from "./message";
+import { acknowledge, claim, consume, isMessage, list, quarantine, read, send } from "./message";
 
 let root: string;
 const AGENT = "test-agent";
@@ -95,6 +95,48 @@ test("read throws on invalid message format", async () => {
   await Bun.file(join(inboxDir, "bad.msg")).write(JSON.stringify({ invalid: true }));
 
   expect(read(inboxDir, "bad.msg")).rejects.toThrow("Invalid message format");
+});
+
+// --- claim ---
+
+test("claim reads message and moves it to .in-progress", async () => {
+  const msg = await send(root, AGENT, "sender", "claim test");
+  const inboxDir = join(root, AGENT, "inbox");
+  const files = await list(inboxDir);
+  const filename = files[0] as string;
+
+  const result = await claim(inboxDir, filename);
+  expect(result).toEqual(msg);
+
+  // Original file should be gone from inbox
+  const remaining = await list(inboxDir);
+  expect(remaining).toEqual([]);
+
+  // Should exist in .in-progress
+  const inProgressFile = Bun.file(join(inboxDir, ".in-progress", filename));
+  expect(await inProgressFile.exists()).toBe(true);
+});
+
+// --- acknowledge ---
+
+test("acknowledge moves message from .in-progress to .processed", async () => {
+  await send(root, AGENT, "sender", "ack test");
+  const inboxDir = join(root, AGENT, "inbox");
+  const files = await list(inboxDir);
+  const filename = files[0] as string;
+
+  // First claim it
+  await claim(inboxDir, filename);
+
+  // Then acknowledge it
+  await acknowledge(inboxDir, filename);
+
+  // Should not exist in .in-progress
+  expect(await Bun.file(join(inboxDir, ".in-progress", filename)).exists()).toBe(false);
+
+  // Should exist in .processed
+  const processedFile = Bun.file(join(inboxDir, ".processed", filename));
+  expect(await processedFile.exists()).toBe(true);
 });
 
 // --- consume ---

--- a/packages/runtime/src/message.ts
+++ b/packages/runtime/src/message.ts
@@ -101,11 +101,25 @@ export async function quarantine(dir: string, filename: string): Promise<void> {
   await rename(join(dir, filename), join(unreadableDir, filename));
 }
 
-/** Read, parse, and move a message to .processed/, returning its parsed content. */
-export async function consume(dir: string, filename: string) {
+/** Move a message from inbox to .in-progress/ and return its parsed content. */
+export async function claim(dir: string, filename: string): Promise<Message> {
   const msg = await read(dir, filename);
+  const inProgressDir = join(dir, ".in-progress");
+  await mkdir(inProgressDir, { recursive: true });
+  await rename(join(dir, filename), join(inProgressDir, filename));
+  return msg;
+}
+
+/** Move a message from .in-progress/ to .processed/. */
+export async function acknowledge(dir: string, filename: string): Promise<void> {
   const processedDir = join(dir, ".processed");
   await mkdir(processedDir, { recursive: true });
-  await rename(join(dir, filename), join(processedDir, filename));
+  await rename(join(dir, ".in-progress", filename), join(processedDir, filename));
+}
+
+/** Read, parse, and move a message to .processed/, returning its parsed content. */
+export async function consume(dir: string, filename: string): Promise<Message> {
+  const msg = await claim(dir, filename);
+  await acknowledge(dir, filename);
   return msg;
 }


### PR DESCRIPTION
## Summary
- Split `consume()` into `claim()` (inbox → `.in-progress/`) and `acknowledge()` (`.in-progress/` → `.processed/`) to support crash recovery per ADR-003/ADR-005
- `consume()` preserved as a convenience wrapper calling both
- Tests verify filesystem state at each phase

## Test plan
- [x] `claim` test: message moves to `.in-progress/`, returns parsed content
- [x] `acknowledge` test: message moves from `.in-progress/` to `.processed/`
- [x] Existing `consume` test still passes
- [x] All 63 tests pass, lint and build clean

Closes #12