### PR TITLE
✨ feat(runtime): add loomHome() resolver

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://biomejs.dev/schemas/2.4.9/schema.json",
   "files": {
-    "includes": ["**", "!**/dist"]
+    "includes": ["**", "!**/dist", "!**/.claude"]
   },
   "formatter": {
     "enabled": true,

--- a/packages/runtime/src/env.test.ts
+++ b/packages/runtime/src/env.test.ts
@@ -1,0 +1,28 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { loomHome } from "./env";
+
+let original: string | undefined;
+
+beforeEach(() => {
+  original = process.env.LOOM_HOME;
+});
+
+afterEach(() => {
+  if (original === undefined) {
+    delete process.env.LOOM_HOME;
+  } else {
+    process.env.LOOM_HOME = original;
+  }
+});
+
+test("returns LOOM_HOME when set", () => {
+  process.env.LOOM_HOME = "/custom/loom";
+  expect(loomHome()).toBe("/custom/loom");
+});
+
+test("falls back to ~/.loom when LOOM_HOME is unset", () => {
+  delete process.env.LOOM_HOME;
+  expect(loomHome()).toBe(join(homedir(), ".loom"));
+});

--- a/packages/runtime/src/env.ts
+++ b/packages/runtime/src/env.ts
@@ -1,0 +1,7 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+/** Resolves the base directory for loom state. Uses $LOOM_HOME if set, otherwise ~/.loom. */
+export function loomHome(): string {
+  return process.env.LOOM_HOME ?? join(homedir(), ".loom");
+}

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1,4 +1,5 @@
 export { type AgentEntry, AgentProcess, type AgentStatus } from "./agent-process";
+export { loomHome } from "./env";
 export { InboxRouter, type InboxRouterOptions } from "./inbox-router";
 export { InboxWatcher, type InboxWatcherOptions } from "./inbox-watcher";
 export { acknowledge, claim, consume, list, type Message, quarantine, read, send } from "./message";


### PR DESCRIPTION
Closes #43

## Summary
- Add `loomHome()` to `@losoft/loom-runtime` — returns `$LOOM_HOME` or `~/.loom`
- Export from the runtime barrel
- Unit tests for both env-set and fallback cases
- Exclude `.claude/` from biome checks

## Test plan
- [x] `bun test --filter env` — 2 tests pass
- [x] `bun run build` — clean
- [x] `bun run check` — no errors