### PR TITLE
✨ feat(runner): add Provider interface and ProviderRegistry

### DIFF
--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -1,1 +1,7 @@
-console.log("Hello from the runner package!");
+export {
+  type ChatMessage,
+  type ChatResponse,
+  type Provider,
+  ProviderRegistry,
+  type ToolCall,
+} from "./provider";

--- a/packages/runner/src/provider.test.ts
+++ b/packages/runner/src/provider.test.ts
@@ -1,0 +1,25 @@
+import { expect, test } from "bun:test";
+import { type Provider, ProviderRegistry } from "./provider";
+
+test("register and get a provider", () => {
+  const registry = new ProviderRegistry();
+  const provider: Provider = {
+    chat: async () => ({ text: "hi" }),
+  };
+  registry.register("test", provider);
+  expect(registry.get("test")).toBe(provider);
+});
+
+test("get returns undefined for unknown provider", () => {
+  const registry = new ProviderRegistry();
+  expect(registry.get("missing")).toBeUndefined();
+});
+
+test("register overwrites existing provider", () => {
+  const registry = new ProviderRegistry();
+  const a: Provider = { chat: async () => ({ text: "a" }) };
+  const b: Provider = { chat: async () => ({ text: "b" }) };
+  registry.register("p", a);
+  registry.register("p", b);
+  expect(registry.get("p")).toBe(b);
+});

--- a/packages/runner/src/provider.ts
+++ b/packages/runner/src/provider.ts
@@ -1,0 +1,41 @@
+/** A single message in a conversation turn. */
+export interface ChatMessage {
+  role: "user" | "assistant" | "tool";
+  content: string;
+  /** Tool call ID — required when role is "tool". */
+  toolCallId?: string;
+}
+
+/** A tool invocation requested by the LLM. */
+export interface ToolCall {
+  id: string;
+  name: string;
+  input: Record<string, unknown>;
+}
+
+/** Response returned by a Provider after a chat turn. */
+export interface ChatResponse {
+  text: string;
+  toolCalls?: ToolCall[];
+}
+
+/** Pluggable LLM backend. */
+export interface Provider {
+  /** Send a chat turn and return the model's response. */
+  chat(model: string, system: string, messages: ChatMessage[]): Promise<ChatResponse>;
+}
+
+/** Registry mapping provider names to Provider implementations. */
+export class ProviderRegistry {
+  private readonly providers = new Map<string, Provider>();
+
+  /** Register a provider under the given name. */
+  register(name: string, provider: Provider): void {
+    this.providers.set(name, provider);
+  }
+
+  /** Retrieve a provider by name, or undefined if not registered. */
+  get(name: string): Provider | undefined {
+    return this.providers.get(name);
+  }
+}


### PR DESCRIPTION
Closes #18

## Summary
- Define `Provider` interface with `chat(model, system, messages)` method
- Define `ChatMessage`, `ChatResponse`, and `ToolCall` supporting types
- Implement `ProviderRegistry` with `register()` and `get()` by name
- Replace runner package stub with real barrel exports

## Test plan
- [x] `bun test --filter provider` — 3 tests pass
- [x] `bun run build` — clean
- [x] `bun run check` — no errors