### PR TITLE
📝 docs: audit ADRs, update README, and fix CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,24 +21,28 @@ bun run format           # format only
 
 Default to using Bun instead of Node.js for all commands.
 
+A pre-commit hook runs `biome check --staged`, `bun run build`, and `bun test` on every commit. It is activated automatically by `bun install` (via the `prepare` script).
+
 ## Monorepo structure
 
-- **`packages/runtime`** (`@losoft/loom-runtime`) — Zero-dependency core primitives: `AgentProcess` (filesystem-backed agent state), `ProcessTable`, `InboxWatcher` (polling-based), `InboxRouter`, and message utilities (`send`, `read`, `consume`, `list`, `quarantine`). No external runtime dependencies allowed.
-- **`packages/runner`** (`@losoft/loom-runner`) — Connects an agent's inbox to an LLM via the provider abstraction. Depends on `@losoft/loom-runtime`. Contains `AgentRunner` and the `Provider`/`ProviderRegistry` interfaces with `resolveProvider()` for model routing by prefix (ollama, anthropic, openai, openrouter).
+- **`packages/runtime`** (`@losoft/loom-runtime`) — Zero-dependency core primitives: `AgentProcess` (filesystem-backed agent state), `ProcessTable`, `InboxWatcher` (polling-based), `InboxRouter`, and message utilities (`send`, `read`, `claim`, `acknowledge`, `consume`, `list`, `quarantine`). No external runtime dependencies allowed.
+- **`packages/runner`** (`@losoft/loom-runner`) — Will connect an agent's inbox to an LLM via the provider abstraction. Depends on `@losoft/loom-runtime`. See ADR-005 for the architecture. Currently scaffolded only.
+- **`packages/supervisor`** (`@losoft/loom-supervisor`) — Process manager: spawns runners, detects crashes, restarts with backoff. Contains `Supervisor` class and restart policy logic (`RestartPolicy`, `CrashRecord`, `computeBackoff`). See ADR-004.
+- **`packages/cli`** (`@losoft/loom-cli`) — CLI entry point (`loom run`, `loom up`, `loom ps`, etc). Depends on all other packages. See ADR-006. Commands are currently stubs.
 - **`tools/`** — Build scripts (e.g. `build-publish-package.ts`).
 
 Each package builds for both Bun and Node.js targets (`dist/bun/` and `dist/node/`).
 
 ## Key architecture concepts
 
-- **Agents are processes** — each agent has a directory under `$LOOM_HOME/agents/{name}/` with plain-text files for `pid`, `status`, `model`, and subdirectories for `inbox/`, `outbox/`, `memory/`, `logs/`, `crashes/`.
-- **Messages are files** — `.msg` JSON files named `{timestamp}-{id}.msg`. Consumed messages move to `.processed/`; unreadable ones go to `.unreadable/`.
-- **Model routing** — model strings use prefix-based routing: no prefix = Ollama (default), `ollama/`, `anthropic/`, `openai/`, `openrouter/`. See `resolveProvider()` in `packages/runner/src/provider.ts`.
+- **Agents are processes** — each agent has a directory under `$LOOM_HOME/agents/{name}/` with plain-text files for `pid`, `status`, `model`, and subdirectories for `inbox/`, `outbox/`, `memory/`, `logs/`, `crashes/`. `$LOOM_HOME` defaults to `~/.loom` (see `loomHome()` in `packages/runtime/src/env.ts`). **Gotcha:** APIs like `AgentProcess`, `ProcessTable`, `InboxWatcher.forAgent()`, and `InboxRouter` take a `home` parameter that must be the agents root (`$LOOM_HOME/agents`), not `$LOOM_HOME` itself.
+- **Messages are files** — `.msg` JSON files named `{timestamp_ms}-{id}.msg`. Three-phase lifecycle: pending (`inbox/`) → claimed (`inbox/.in-progress/`) → processed (`inbox/.processed/`). Unreadable messages go to `inbox/.unreadable/`.
+- **Runners are self-sufficient** — each runner is an OS process that owns its agent's full lifecycle (inbox polling, LLM calls, tool execution, outbox writes, status updates). The supervisor is a process manager only — it spawns runners and handles restarts but does not mediate messages.
 - **ADRs** — Architecture decision records live in `docs/adrs/`. New design decisions require an ADR.
 
 ## Code conventions
 
-- TypeScript strict mode. Biome for linting/formatting (spaces, double quotes, semicolons, trailing commas).
+- TypeScript strict mode. Biome for linting/formatting (spaces, double quotes, semicolons, trailing commas, 100-char line width).
 - Tests live alongside source as `*.test.ts` files. Tests should verify filesystem state, not just return values.
 - Commits use Conventional Commits with gitmoji (e.g. `✨ feat:`, `🐛 fix:`, `📝 docs:`, `♻️ refactor:`, `🧪 test:`).
 - Every public function needs a one-line JSDoc comment.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # loom
 
-> Weave agents into systems. A local-first runtime where agents are processes, state is files, and everything is observable.
-
-A local-first agent runtime. Agents are processes. All state lives in the filesystem. Nothing is hidden.
+> A local-first agent runtime where agents are Unix processes, all state lives in the filesystem, and everything is observable with standard Unix tools.
 
 ---
 
@@ -14,33 +12,38 @@ loom does the opposite.
 
 ## Core idea
 
-An agent is a long-running process. It has an identity, a working directory, an inbox, and an outbox. Agents communicate by writing files. The supervisor watches them and restarts on crash. You can observe everything with standard Unix tools.
+An agent is a Unix process. It has an identity, a status, an inbox, and an outbox. Agents communicate by writing files. The supervisor watches them and restarts on crash. You can observe everything with `cat`, `tail`, `grep`, and `ls`.
 
 ```
-$LOOM_HOME/
-  agents/
-    my-agent/
-      pid          # current process id
-      status       # running | idle | dead
-      model        # model in use
-      inbox/       # drop a .msg file here to send a message
-      outbox/      # agent writes responses here
-      memory/      # persistent key-value state
-      logs/        # append-only structured log, one file per day
-      crashes/     # crash records (if any)
-  supervisor.pid   # supervisor process id
-  pipes/           # active agent-to-agent wiring
+$LOOM_HOME/agents/{name}/
+  pid            # OS process ID of the running runner
+  status         # running | idle | stopped | pending | dead | error | restarting
+  model          # model identifier in use
+  started_at     # ISO 8601 timestamp
+  stopped_at     # ISO 8601 timestamp (empty if still running)
+  inbox/         # incoming messages as .msg files
+    .in-progress/  # messages currently being processed (claimed)
+    .processed/    # successfully processed messages
+    .failed/       # messages that failed after all retries
+    .unreadable/   # messages that could not be parsed
+  outbox/        # outgoing messages as .msg files
+  memory/        # persistent key-value state as .json files
+  logs/          # append-only NDJSON log files, one per day
+  crashes/       # crash records (if any)
+$LOOM_HOME/supervisor.pid   # supervisor process ID
 ```
+
+Messages are JSON files named `{timestamp_ms}-{id}.msg`. The timestamp prefix gives human-readable ordering in directory listings.
 
 ---
 
 ## Platform support
 
-loom relies on Unix process semantics (POSIX signals, pid-based supervision, file descriptor inheritance). It runs on:
+loom relies on Unix process semantics (POSIX signals, PID-based supervision, file descriptor inheritance). It runs on:
 
-- **Linux** — x64, arm64
-- **macOS** — x64, arm64
-- **Windows** — via [WSL](https://learn.microsoft.com/en-us/windows/wsl/) (use the Linux binary inside WSL)
+- **Linux** -- x64, arm64
+- **macOS** -- x64, arm64
+- **Windows** -- via [WSL](https://learn.microsoft.com/en-us/windows/wsl/) (use the Linux binary inside WSL)
 
 Native Windows is not supported.
 
@@ -51,7 +54,6 @@ Native Windows is not supported.
 ### Prerequisites
 
 - [Bun](https://bun.sh) 1.3+
-- [Ollama](https://ollama.com) running locally (or any OpenAI-compatible endpoint)
 
 ### Build from source
 
@@ -62,70 +64,38 @@ bun install
 bun run build
 ```
 
-### Start a single agent
-
-```sh
-# Pull a model (if using Ollama)
-ollama pull qwen2.5:3b
-
-# Scaffold a starter loom.yml
-loom init
-
-# Edit loom.yml — set the model and system prompt:
-# version: 1
-# agents:
-#   - name: my-agent
-#     model: qwen2.5:3b
-#     system: "You are a helpful assistant."
-
-# Start the agent
-loom spawn my-agent
-
-# Send it a message
-loom send my-agent "What is the capital of France?"
-
-# Read the response
-loom read my-agent
-```
-
-### Validate a config
-
-```sh
-# Check your loom.yml is valid before using it
-loom validate
-
-# Point at a specific file
-loom validate --file ./config/agents.yml
-
-# Machine-readable output
-loom validate --json
-```
-
 ---
 
 ## CLI
 
+Two primary commands cover the full lifecycle:
+
 ```sh
-# Weave
-loom up [--follow, -f]                            # start supervisor and all agents from loom.yml
-loom down                                         # stop supervisor and all agents
-loom ps                                           # list agents and their status
+# Single agent -- foreground (interactive, streams to terminal)
+loom run --name my-agent --model qwen3.5:9b
 
-# Agents
-loom spawn <name>                                 # start an agent from loom.yml
-loom kill <name>                                  # kill an agent process
-loom log <name> [--follow, -f]                    # stream agent logs
+# Single agent -- background (supervised, restarts on crash)
+loom run --name my-agent --model qwen3.5:9b --detach
 
-# Messaging
-loom send <name> "<message>"                      # send a message to an agent's inbox
-loom read <name>                                  # read latest outbox message(s)
-loom inbox <name> [--follow, -f]                  # show pending inbox messages
-loom outbox <name> [--follow, -f]                 # show outbox messages
-
-# Config
-loom validate [--file <path>]                     # validate loom.yml against schema and pipe rules
-loom init                                         # scaffold a starter loom.yml
+# Multi-agent weave from loom.yml
+loom up
 ```
+
+Supporting commands:
+
+```sh
+loom ps                    # list agents and their status
+loom stop <name>           # stop a specific agent
+loom logs <name>           # view agent logs
+loom send <name> <msg>     # send a message to an agent's inbox
+loom down                  # stop all agents started by loom up
+```
+
+| Mode | Supervisor | Restart on crash | Pipe engine |
+|------|-----------|-----------------|-------------|
+| `loom run` (foreground) | No | No | No |
+| `loom run --detach` | Yes | Yes | Yes |
+| `loom up` | Yes | Yes | Yes |
 
 ---
 
@@ -134,88 +104,46 @@ loom init                                         # scaffold a starter loom.yml
 - Any language can read a file. No SDK required to observe an agent.
 - `tail -f logs/my-agent` works. `ls inbox/` works. `cat status` works.
 - State survives process crashes. Inbox messages are not lost.
-- Works offline. No cloud dependency. No API key required to run.
+- Works offline. No cloud dependency. No API key required to run locally.
 - Composable with Unix tools: `watch`, `grep`, `jq`, `cron`.
-
----
-
-## Pluggable models
-
-loom routes models by prefix — Ollama (default), Anthropic, OpenAI, and OpenRouter are all supported. Any OpenAI-compatible endpoint also works:
-
-```sh
-# Local via Ollama (default — no prefix needed)
-loom spawn my-agent --model qwen2.5:3b
-
-# Explicit Ollama prefix
-loom spawn my-agent --model ollama/qwen3.5:9b
-
-# Anthropic (set ANTHROPIC_API_KEY)
-ANTHROPIC_API_KEY=sk-ant-... \
-loom spawn my-agent --model anthropic/claude-sonnet-4-6
-
-# OpenAI (set OPENAI_API_KEY)
-OPENAI_API_KEY=sk-... \
-loom spawn my-agent --model openai/gpt-4o
-
-# OpenRouter (set OPENROUTER_API_KEY)
-OPENROUTER_API_KEY=sk-or-... \
-loom spawn my-agent --model openrouter/anthropic/claude-3.5-sonnet
-```
-
-| Prefix | Provider | Env vars |
-|--------|----------|----------|
-| _(none)_ | Ollama | `OLLAMA_BASE_URL` (default: `http://localhost:11434/v1`) |
-| `ollama/` | Ollama | `OLLAMA_BASE_URL` |
-| `anthropic/` | Anthropic | `ANTHROPIC_API_KEY`, `ANTHROPIC_BASE_URL` |
-| `openai/` | OpenAI | `OPENAI_API_KEY`, `OPENAI_BASE_URL` |
-| `openrouter/` | OpenRouter | `OPENROUTER_API_KEY` |
-
-See [`docs/adrs/drafts/model-routing.md`](docs/adrs/drafts/model-routing.md) for the full model routing spec.
 
 ---
 
 ## Architecture
 
+The system has three main components:
+
+**Runner** -- one per agent. A self-sufficient OS process that polls its inbox, calls the LLM, executes tools, writes responses to the outbox, and maintains its own state files. Runners work standalone without a supervisor.
+
+**Supervisor** -- a process manager. Spawns runners, detects crashes via child process exit events, restarts with exponential backoff, and runs the pipe engine for inter-agent communication. If the supervisor dies, runners keep running -- they just lose restart protection.
+
+**Filesystem** -- the source of truth. All state is plain files. The CLI writes to the filesystem; the supervisor reads it. A SIGHUP signal nudges the supervisor to re-scan immediately.
+
 ```
-┌──────────────────────────────────────────────────────┐
-│  loom supervisor (single long-running process)      │
-│                                                      │
-│  ┌────────────┐   ┌────────────┐   ┌─────────────┐  │
-│  │ inbox      │   │ agent A    │   │ pipe engine │  │
-│  │ watcher    │──▶│ (spawned)  │──▶│ (outbox →   │  │
-│  │ (polling)  │   │            │   │  inbox)     │  │
-│  └────────────┘   └────────────┘   └─────────────┘  │
-│                                                      │
-│  ┌────────────────────────────────────────────────┐  │
-│  │ health monitor (heartbeat every 5s)            │  │
-│  │  → detects dead agents                         │  │
-│  │  → applies restart policy with backoff         │  │
-│  └────────────────────────────────────────────────┘  │
-└──────────────────────────────────────────────────────┘
-                        │
-                        │ reads/writes
-                        ▼
-┌──────────────────────────────────────────────────────┐
-│  $LOOM_HOME/agents/{name}/                          │
-│    pid  status  inbox/  outbox/  memory/  logs/      │
-└──────────────────────────────────────────────────────┘
-                        │
-                        │ any process can read/write
-                        ▼
-              standard Unix tools
-              cat, tail, grep, jq, watch
+Runner (one per agent)              Supervisor (process manager)
+  ├── polls inbox/ (200ms)            ├── spawns runners
+  ├── claims message → .in-progress/  ├── detects crashes (child exit)
+  ├── calls LLM via provider          ├── restarts with backoff
+  ├── writes response to outbox/      ├── runs pipe engine
+  ├── acknowledges → .processed/      └── writes crash records
+  └── updates status (running/idle)
 ```
 
-Each agent is a spawned child process. The supervisor watches for crashes and
-restarts with exponential backoff. If the supervisor dies, agents keep running —
-they just won't be restarted until the supervisor comes back.
+### Restart policy
+
+Each agent has a restart policy: `always` (default), `on-failure`, or `never`. Exponential backoff with jitter prevents runaway restart loops:
+
+```
+delay = min(1s * 2^restartCount, 5m) + jitter(0..500ms)
+```
+
+After 10 failures within one hour, the agent is marked `dead` and the supervisor stops restarting it.
 
 ---
 
 ## Design decisions
 
-Architecture decision records live in [`docs/adrs/`](docs/adrs/). Accepted ADRs are numbered; drafts live in [`docs/adrs/drafts/`](docs/adrs/drafts/) and receive a number once approved.
+Architecture decision records live in [`docs/adrs/`](docs/adrs/).
 
 ### Accepted
 
@@ -225,6 +153,8 @@ Architecture decision records live in [`docs/adrs/`](docs/adrs/). Accepted ADRs 
 | [ADR-002](docs/adrs/ADR-002-filesystem-as-process-table.md) | Filesystem as process table |
 | [ADR-003](docs/adrs/ADR-003-inbox-watcher-polling.md) | Inbox watcher via polling |
 | [ADR-004](docs/adrs/ADR-004-supervisor-and-restart-policy.md) | Supervisor and restart policy |
+| [ADR-005](docs/adrs/ADR-005-runner-architecture.md) | Runner architecture |
+| [ADR-006](docs/adrs/ADR-006-cli-and-lifecycle.md) | CLI and agent lifecycle |
 
 ### Drafts
 
@@ -234,8 +164,8 @@ Architecture decision records live in [`docs/adrs/`](docs/adrs/). Accepted ADRs 
 | [plugin-model](docs/adrs/drafts/plugin-model.md) | Plugin and extension model |
 | [model-routing](docs/adrs/drafts/model-routing.md) | Model routing and provider abstraction |
 | [filesystem-state-store](docs/adrs/drafts/filesystem-state-store.md) | Filesystem as state store |
-| [plugin-protocol](docs/adrs/drafts/plugin-protocol.md) | Plugin protocol — tools as executables |
-| [pipe-engine](docs/adrs/drafts/pipe-engine.md) | Pipe engine — outbox-to-inbox forwarding |
+| [plugin-protocol](docs/adrs/drafts/plugin-protocol.md) | Plugin protocol -- tools as executables |
+| [pipe-engine](docs/adrs/drafts/pipe-engine.md) | Pipe engine -- outbox-to-inbox forwarding |
 
 ---
 

--- a/docs/adrs/ADR-001-unix-process-model.md
+++ b/docs/adrs/ADR-001-unix-process-model.md
@@ -32,17 +32,19 @@ We need a model that:
 This is not a metaphor. It is the actual design.
 
 A loom agent:
-- Has a unique identifier (the PID — a short content hash)
-- Has a working directory (`cwd`)
-- Has environment variables (`env`)
-- Has standard I/O channels (`stdin`, `stdout`, `stderr`)
-- Has a status (`running`, `idle`, `waiting`, `stopped`, `exited`)
-- Has a parent (the process that spawned it, or PID 1 for top-level agents)
+- Has a unique identifier (the PID — the OS process ID of the running runner)
+- Has a status (`running`, `idle`, `stopped`, `pending`, `dead`, `error`, `restarting`)
+- Has a parent (the supervisor that spawned it, or runs standalone in foreground mode)
 - Has an exit code when it terminates
+
+In foreground mode (`loom run`), an agent inherits its parent's working directory,
+environment variables, and standard I/O channels. In detached mode
+(`loom run --detach`), these are managed by the supervisor. These are OS-level
+properties of the runner process, not filesystem-stored fields.
 
 The `loom ps` command is exactly `ps` for agents.
 
-Signals work as expected: SIGTERM triggers graceful shutdown, SIGKILL forces termination, SIGSTOP/SIGCONT pause and resume.
+SIGTERM triggers graceful shutdown (used by `loom stop`), SIGKILL forces termination, and SIGHUP nudges the supervisor to re-scan agent directories. SIGSTOP/SIGCONT for pause/resume are not currently implemented.
 
 ## Consequences
 
@@ -60,13 +62,13 @@ Signals work as expected: SIGTERM triggers graceful shutdown, SIGKILL forces ter
 
 ### Tricky
 
-**PIDs need content-addressing.** Unix PIDs are integers assigned by the kernel; loom PIDs are short hashes derived from the agent's identity (name + model + spawn time). This makes them stable across restarts but not strictly ordered. Commands like `loom ps --sort=pid` need to sort by time, not numeric value.
+**PIDs are OS integers, not content hashes.** Unlike earlier designs that proposed content-addressed PIDs, loom uses the OS process ID of the running runner. PIDs change on every restart and are not stable identifiers — the agent *name* is the stable identifier. `loom ps` sorts by name, not PID.
 
-**stdin/stdout semantics change.** A Unix process reads stdin once; a loom agent may read from its inbox many times over its lifetime. We resolve this by distinguishing `loom run` (ephemeral, true stdin) from `loom spawn` (persistent, inbox-based). The model is consistent but the two modes need clear documentation.
+**stdin/stdout semantics change.** A Unix process reads stdin once; a loom agent may read from its inbox many times over its lifetime. We resolve this by distinguishing `loom run` (foreground, true stdin) from `loom run --detach` (persistent, inbox-based). The model is consistent but the two modes need clear documentation.
 
 **No kernel.** Unix processes have the kernel as a mediator — it enforces scheduling, handles signals, manages memory. loom has no equivalent. We use file locks and filesystem primitives to simulate isolation, but they are advisory, not mandatory. This is acceptable for local-first use cases.
 
-**Process table is a directory, not kernel memory.** `loom ps` reads from `~/.loom/agents/*/meta.json`. This means a crashed agent might still appear as "running." We add a heartbeat field to `meta.json` and treat stale heartbeats (>30s) as crashed. A future GC command (`loom gc`) will clean them up.
+**Process table is a directory, not kernel memory.** `loom ps` reads from `$LOOM_HOME/agents/*/status` and other plain-text files (see ADR-002). This means a crashed agent might still appear as "running" until the supervisor detects the crash via child process exit events and updates the status file. On supervisor startup, stale PIDs are detected via `process.kill(pid, 0)` (see ADR-004). A future GC command (`loom gc`) will clean up old crash records and processed messages.
 
 ## Alternatives Considered
 
@@ -91,3 +93,16 @@ Always an option. Rejected because the Unix process model is already deeply unde
 - [The Art of Unix Programming](http://www.catb.org/esr/writings/taoup/) — especially chapter 1 and the philosophy of composability
 - Plan 9 from Bell Labs — processes and files, taken further than Unix
 - [Nix processes](https://nixos.wiki/wiki/Nix_expression_language) — content-addressed identifiers in process/package systems
+
+---
+
+## Changelog
+
+| Date | Change |
+|---|---|
+| 2026-03-31 | **PID definition corrected.** Changed from "short content hash" to OS process ID integer. The agent *name* is the stable identifier, not the PID. |
+| 2026-03-31 | **Removed `meta.json` and heartbeat references.** The process table uses plain-text files per ADR-002, not a single `meta.json`. Stale process detection uses `process.kill(pid, 0)` per ADR-004. |
+| 2026-03-31 | **Status values aligned with code.** Updated from `running | idle | waiting | stopped | exited` to `running | idle | stopped | pending | dead | error | restarting`. |
+| 2026-03-31 | **Clarified `cwd`, `env`, `stdin`/`stdout`/`stderr` scope.** These are OS-level properties of the runner process, not filesystem-stored fields. |
+| 2026-03-31 | **Signals updated.** SIGSTOP/SIGCONT marked as not currently implemented. Added SIGHUP for supervisor re-scan. |
+| 2026-03-31 | **Replaced `loom spawn` with `loom run --detach`.** Aligns with ADR-006 which consolidated spawn into `run --detach`. |

--- a/docs/adrs/ADR-002-filesystem-as-process-table.md
+++ b/docs/adrs/ADR-002-filesystem-as-process-table.md
@@ -16,7 +16,7 @@ The loom process table is a directory. Each agent has a subdirectory under `$LOO
 ```
 $LOOM_HOME/agents/{name}/
   pid           plain text — current OS process ID, empty if not running
-  status        plain text — one of: running | idle | stopped | dead | error | restarting
+  status        plain text — one of: running | idle | stopped | pending | dead | error | restarting
   model         plain text — model identifier in use
   started_at    plain text — ISO 8601 timestamp
   stopped_at    plain text — ISO 8601 timestamp, empty if still running
@@ -84,7 +84,7 @@ It is used for idempotent restart recovery: when a runner restarts, it checks
 determine if reprocessing is needed (see ADR-005).
 
 The `v` field is the schema version. It allows safe migration when the message format changes:
-- Missing `v` → treated as `v: 1` (backwards compat for files written before versioning was added)
+- Missing `v` → fails validation (`isMessage()` requires `v` to be present and numeric). The message is quarantined as unreadable.
 - `v` newer than the runtime's `MESSAGE_VERSION` → runtime throws with a clear error message asking the operator to upgrade loom
 - `v` equal or older → parsed normally
 
@@ -140,3 +140,12 @@ mv agents/researcher/inbox/.failed/1742860000000-a3f9c1d2e5b87041.msg agents/res
 **Redis/TCP pub-sub:** Fast, flexible. But requires a running server, network connectivity, and is invisible to standard Unix tools. Ruled out for core; may be added as optional remote transport later.
 
 **In-memory EventEmitter:** Simple, zero latency. But state is lost on crash and invisible to operators. Ruled out.
+
+---
+
+## Changelog
+
+| Date | Change |
+|---|---|
+| 2026-03-31 | **Added `pending` to status values.** ADR-004 and ADR-006 require writing `status: pending` for newly created detached agents. Added to the canonical set. |
+| 2026-03-31 | **Fixed `v` field backwards-compat rule.** Changed "missing `v` → treated as `v: 1`" to "missing `v` → fails validation, message is quarantined." The `v` field is required for all messages. |

--- a/docs/adrs/ADR-003-inbox-watcher-polling.md
+++ b/docs/adrs/ADR-003-inbox-watcher-polling.md
@@ -25,18 +25,10 @@ The implementation is split into two layers:
   the agent name prepended: `(agentName, filename, message)`. This is the multi-agent
   coordinator.
 
-**Current implementation:** Consumed files are moved directly from `inbox/`
-to `inbox/.processed/` via the `consume()` function. This is a two-phase model
-(pending → processed).
+### Three-phase message lifecycle
 
-### Target: three-phase message lifecycle
-
-> **Not yet implemented.** The following describes the target design for
-> reliable delivery with idempotent restart recovery. The current runtime
-> uses the simpler two-phase model above. See ADR-005 for the runner
-> architecture that will implement this.
-
-The target lifecycle adds an intermediate `.in-progress/` phase:
+The message lifecycle uses three filesystem phases for reliable delivery
+with idempotent restart recovery (see ADR-005):
 
 ```
 inbox/
@@ -57,10 +49,7 @@ InboxWatcher.poll()
   list *.msg files in inbox/ (sorted by filename → oldest first)
   for each file:
     read + parse JSON
-    move to inbox/.in-progress/         ← claim the message
     emit('message', filename, message)
-    (runner processes the message, writes response to outbox/)
-    move to inbox/.processed/           ← acknowledge completion
 
 InboxRouter.add(agent)
   create InboxWatcher.forAgent(home, agent)
@@ -68,9 +57,19 @@ InboxRouter.add(agent)
   start watcher
 ```
 
-### Restart recovery (target design)
+The watcher emits events; the **runner** (ADR-005) owns the three-phase
+transitions. When the runner receives a message event, it:
 
-On startup, the runner will check `inbox/.in-progress/` for messages that were
+1. Calls `claim()` — moves the file to `inbox/.in-progress/`
+2. Processes the message (LLM call, tool execution, writes response to `outbox/`)
+3. Calls `acknowledge()` — moves the file to `inbox/.processed/`
+
+This separation keeps `InboxWatcher` simple (detection only) while giving the
+runner control over the claim-process-acknowledge lifecycle.
+
+### Restart recovery
+
+On startup, the runner checks `inbox/.in-progress/` for messages that were
 mid-processing when it last crashed:
 
 ```
@@ -80,7 +79,7 @@ for each file in inbox/.in-progress/:
   if not found → processing did not complete, move back to inbox/ for reprocessing
 ```
 
-This will provide at-least-once delivery with no duplicate responses: if the
+This provides at-least-once delivery with no duplicate responses: if the
 outbox already contains the response, the runner skips reprocessing and just
 finishes the acknowledgment.
 
@@ -119,3 +118,17 @@ so `ls inbox/` still gives a clean view of pending messages.
 - `InboxRouter` manages multiple `InboxWatcher` instances, emits
   `(agentName, filename, message)`. Multi-agent callers (e.g. supervisor) use it
   via `router.add(agent)` / `router.remove(agent)` / `router.stop()`.
+- **`home` parameter convention:** `InboxWatcher.forAgent(home, name)` and
+  `InboxRouter` expect `home` to be the agents root directory
+  (`$LOOM_HOME/agents`), not `$LOOM_HOME` itself. The watcher constructs the
+  inbox path as `{home}/{name}/inbox/`.
+
+---
+
+## Changelog
+
+| Date | Change |
+|---|---|
+| 2026-03-31 | **Removed "not yet implemented" note.** The three-phase lifecycle (claim → process → acknowledge) is the decided design, not a future target. |
+| 2026-03-31 | **Clarified watcher vs runner responsibility.** `InboxWatcher` detects and emits; the runner owns the claim/process/acknowledge transitions. Updated pseudocode to reflect this separation. |
+| 2026-03-31 | **Documented `home` parameter convention.** `home` is `$LOOM_HOME/agents`, not `$LOOM_HOME`. |

--- a/docs/adrs/ADR-004-supervisor-and-restart-policy.md
+++ b/docs/adrs/ADR-004-supervisor-and-restart-policy.md
@@ -109,7 +109,9 @@ Defaults:
 
 After `maxRestarts` failures within a `resetWindowMs` (default 3600000ms = 1 hour),
 the agent is considered permanently failed and the supervisor stops restarting it.
-An operator must manually run `loom restart {name}` to resume.
+An operator can resume the agent by writing `status: pending` and sending SIGHUP
+to the supervisor, or by running `loom stop {name}` followed by
+`loom run --name {name} --detach`.
 
 ### Visibility
 
@@ -187,7 +189,7 @@ that hit `maxRestarts` in a previous supervisor session) get a fresh chance afte
 a system reboot or supervisor restart.
 
 The supervisor does not install itself as a system service. That is the operator's job.
-A systemd unit file template is provided in `docs/examples/loom-supervisor.service`.
+A systemd unit file template will be provided in `docs/examples/loom-supervisor.service`.
 
 ## Consequences
 
@@ -222,3 +224,12 @@ The supervisor could watch inboxes and dispatch messages to runners via stdin, r
 responses from stdout. Rejected because it makes the supervisor a critical path for
 all message processing and prevents runners from working standalone. Self-sufficient
 runners (ADR-005) are simpler and more resilient.
+
+---
+
+## Changelog
+
+| Date | Change |
+|---|---|
+| 2026-03-31 | **Removed `loom restart` command reference.** ADR-006 does not define a `loom restart` command. Replaced with the equivalent operator workflow: write `status: pending` + SIGHUP, or stop + re-run detached. |
+| 2026-03-31 | **Fixed systemd unit file reference.** Changed "is provided" to "will be provided" — the file does not exist yet. |

--- a/docs/adrs/ADR-005-runner-architecture.md
+++ b/docs/adrs/ADR-005-runner-architecture.md
@@ -89,8 +89,8 @@ This provides at-least-once delivery with no duplicate responses.
 
 ### Tool execution
 
-The runner executes tools directly by spawning plugin executables (see plugin
-protocol ADR). When the LLM requests a tool call:
+The runner executes tools directly by spawning plugin executables.
+When the LLM requests a tool call:
 
 1. Runner looks up the tool's executable path (provided at init time)
 2. Spawns the plugin: `echo '<input_json>' | <plugin_path> invoke`
@@ -185,3 +185,11 @@ and tight coupling to the supervisor. Rejected.
 - ADR-002: Filesystem as process table — directory layout and message format
 - ADR-003: Inbox watcher polling — three-phase processing lifecycle
 - ADR-004: Supervisor and restart policy — process management and crash recovery
+
+---
+
+## Changelog
+
+| Date | Change |
+|---|---|
+| 2026-03-31 | **Removed dangling "plugin protocol ADR" reference.** The tool execution protocol is described inline in this ADR. A separate plugin protocol ADR may be added in the future if the protocol warrants its own decision record. |

--- a/docs/adrs/ADR-006-cli-and-lifecycle.md
+++ b/docs/adrs/ADR-006-cli-and-lifecycle.md
@@ -184,3 +184,11 @@ be a command, not a function call.
 - ADR-004: Supervisor and restart policy — lifecycle management
 - ADR-005: Runner architecture — what runs inside an agent process
 - loom.yml ADR (draft): Declarative weave configuration for `loom up`
+
+---
+
+## Changelog
+
+| Date | Change |
+|---|---|
+| 2026-03-31 | **Audited against codebase.** No design contradictions found. All commands are forward-looking design specifications. |


### PR DESCRIPTION
## Summary
- Audited all 6 approved ADRs against the codebase and fixed design contradictions (PID definition, status values, stale notes, dangling references)
- Rewrote README to only include information backed by approved ADRs
- Updated CLAUDE.md to reflect actual monorepo structure and add missing packages

## Changes by file
- **ADR-001**: Fixed PID definition (content hash → OS integer), removed meta.json/heartbeat, aligned status values, clarified cwd/env/stdio scope
- **ADR-002**: Added `pending` to status set, fixed `v`-field backwards-compat rule
- **ADR-003**: Removed stale "not yet implemented" note, clarified watcher vs runner responsibility, documented `home` parameter convention
- **ADR-004**: Removed reference to non-existent `loom restart` command, fixed systemd unit file reference
- **ADR-005**: Removed dangling "plugin protocol ADR" reference
- **ADR-006**: Added audit changelog (no contradictions found)
- **README.md**: Rewritten to match approved ADRs only — removed unapproved commands, model routing table, pipes directory
- **CLAUDE.md**: Added missing packages (cli, supervisor), pre-commit hook note, `home` parameter gotcha

## Test plan
- [ ] Verify each ADR changelog accurately describes the change
- [ ] Verify README CLI commands match ADR-006
- [ ] Verify README directory layout matches ADR-002