### PR TITLE
✨ feat: add writeCrashRecord and listCrashRecords to crashes/

### DIFF
--- a/packages/runtime/src/crash.test.ts
+++ b/packages/runtime/src/crash.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { type CrashRecord, listCrashRecords, writeCrashRecord } from "./crash";
+
+let agentDir: string;
+
+const sampleRecord: CrashRecord = {
+  ts: "2026-03-25T05:00:00.000Z",
+  exitCode: 1,
+  signal: null,
+  restartCount: 3,
+  nextRestartAt: "2026-03-25T05:00:16.000Z",
+};
+
+beforeEach(() => {
+  agentDir = mkdtempSync(join(tmpdir(), "crash-"));
+});
+
+afterEach(() => {
+  rmSync(agentDir, { recursive: true, force: true });
+});
+
+test("writeCrashRecord creates crashes/ directory if missing", () => {
+  writeCrashRecord(agentDir, sampleRecord);
+  expect(existsSync(join(agentDir, "crashes"))).toBe(true);
+});
+
+test("writeCrashRecord writes a JSON file to crashes/", () => {
+  writeCrashRecord(agentDir, sampleRecord);
+  const records = listCrashRecords(agentDir);
+  expect(records).toHaveLength(1);
+  expect(records[0]).toEqual(sampleRecord);
+});
+
+test("listCrashRecords returns empty array when no crashes", () => {
+  const records = listCrashRecords(agentDir);
+  expect(records).toEqual([]);
+});
+
+test("listCrashRecords returns records sorted chronologically", async () => {
+  const first: CrashRecord = { ...sampleRecord, restartCount: 1 };
+  writeCrashRecord(agentDir, first);
+  // Small delay to ensure different timestamp_ns values
+  await new Promise((r) => setTimeout(r, 2));
+  const second: CrashRecord = { ...sampleRecord, restartCount: 2 };
+  writeCrashRecord(agentDir, second);
+
+  const records = listCrashRecords(agentDir);
+  expect(records).toHaveLength(2);
+  expect(records[0]!.restartCount).toBe(1);
+  expect(records[1]!.restartCount).toBe(2);
+});
+
+test("writeCrashRecord handles signal crashes", () => {
+  const signalRecord: CrashRecord = {
+    ts: "2026-03-25T06:00:00.000Z",
+    exitCode: null,
+    signal: "SIGKILL",
+    restartCount: 0,
+    nextRestartAt: null,
+  };
+  writeCrashRecord(agentDir, signalRecord);
+  const records = listCrashRecords(agentDir);
+  expect(records[0]).toEqual(signalRecord);
+});

--- a/packages/runtime/src/crash.ts
+++ b/packages/runtime/src/crash.ts
@@ -1,0 +1,49 @@
+/**
+ * @file Crash record utilities for agent crash history.
+ * @module @loom/runtime/crash
+ *
+ * Writes and reads crash records stored as JSON files under `crashes/`
+ * in the agent directory. Each file is named `{timestamp_ns}-{id}.json`.
+ */
+
+import { mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+export interface CrashRecord {
+  /** ISO 8601 timestamp of the crash. */
+  ts: string;
+  /** Process exit code, or null if killed by signal. */
+  exitCode: number | null;
+  /** Signal name if killed by signal, otherwise null. */
+  signal: string | null;
+  /** Number of times the agent has been restarted so far. */
+  restartCount: number;
+  /** ISO 8601 timestamp of the next scheduled restart, or null if no restart planned. */
+  nextRestartAt: string | null;
+}
+
+function generateSuffix(): string {
+  return crypto.randomUUID().replace(/-/g, "").slice(0, 16);
+}
+
+/** Write a crash record to the agent's crashes/ directory. */
+export function writeCrashRecord(agentDir: string, record: CrashRecord): void {
+  const crashesDir = join(agentDir, "crashes");
+  mkdirSync(crashesDir, { recursive: true });
+
+  const tsNs = BigInt(Date.now()) * 1_000_000n;
+  const filename = `${tsNs}-${generateSuffix()}.json`;
+  writeFileSync(join(crashesDir, filename), JSON.stringify(record, null, 2), "utf8");
+}
+
+/** List all crash records for an agent, sorted chronologically (oldest first). */
+export function listCrashRecords(agentDir: string): CrashRecord[] {
+  const crashesDir = join(agentDir, "crashes");
+  mkdirSync(crashesDir, { recursive: true });
+
+  const files = readdirSync(crashesDir)
+    .filter((f) => f.endsWith(".json"))
+    .sort();
+
+  return files.map((f) => JSON.parse(readFileSync(join(crashesDir, f), "utf8")) as CrashRecord);
+}

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1,4 +1,5 @@
 export { type AgentEntry, AgentProcess, type AgentStatus } from "./agent-process";
+export { type CrashRecord, listCrashRecords, writeCrashRecord } from "./crash";
 export { loomHome } from "./env";
 export { InboxRouter, type InboxRouterOptions } from "./inbox-router";
 export { InboxWatcher, type InboxWatcherOptions } from "./inbox-watcher";


### PR DESCRIPTION
Closes #16

Adds crash record utilities to the runtime, as specified in ADR-004. Both the supervisor (which detects crashes) and diagnostic tools need to read/write these records.

## Changes
- New `packages/runtime/src/crash.ts`
- `writeCrashRecord(agentDir, record)` — writes JSON file to `crashes/` named `{timestamp_ns}-{id}.json`
- `listCrashRecords(agentDir)` — returns records sorted chronologically
- `CrashRecord` interface: `{ ts, exitCode, signal, restartCount, nextRestartAt }`
- Exported from index

## Test plan
- [ ] `bun test --filter crash` passes
- [ ] Crash file written to `crashes/` with correct schema
- [ ] `listCrashRecords` returns records in chronological order