### PR TITLE
🧪 test: verify stopped/pending status persists to disk

### DIFF
--- a/packages/runtime/src/agent-process.test.ts
+++ b/packages/runtime/src/agent-process.test.ts
@@ -126,12 +126,14 @@ test("status can be set to stopped", () => {
   const agent = new AgentProcess(home, "alice");
   agent.status = "stopped";
   expect(agent.status).toBe("stopped");
+  expect(readFileSync(join(home, "alice", "status"), "utf8").trim()).toBe("stopped");
 });
 
 test("status can be set to pending", () => {
   const agent = new AgentProcess(home, "alice");
   agent.status = "pending";
   expect(agent.status).toBe("pending");
+  expect(readFileSync(join(home, "alice", "status"), "utf8").trim()).toBe("pending");
 });
 
 test("second AgentProcess for same name reads existing state", () => {


### PR DESCRIPTION
Follow-up to #49 — the two new status tests only checked the in-memory getter. This adds `readFileSync` assertions to verify the value is actually written to the `status` file on disk, per the CLAUDE.md rule: tests should verify filesystem state, not just return values.