### PR TITLE
📝 docs: add @file JSDoc headers to agent-process.ts and env.ts

### DIFF
--- a/packages/runtime/src/agent-process.ts
+++ b/packages/runtime/src/agent-process.ts
@@ -1,3 +1,4 @@
+/** @file Filesystem-backed agent process state — reads and writes per-agent files under $LOOM_HOME/agents/{name}/. */
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 

--- a/packages/runtime/src/env.ts
+++ b/packages/runtime/src/env.ts
@@ -1,3 +1,4 @@
+/** @file Environment helpers — resolves loom runtime paths from env vars with sensible defaults. */
 import { homedir } from "node:os";
 import { join } from "node:path";
 


### PR DESCRIPTION
## Summary

- Adds missing `@file` JSDoc module headers to `agent-process.ts` and `env.ts` in `packages/runtime`
- Brings the package into full compliance with the `@file`/`@module` header requirement in CONTRIBUTING.md

## Test plan

- [x] `bun run check` passes
- [x] `bun run build` passes
- [x] `bun test` passes