### PR TITLE
✨ feat: add bun run loom convenience script and document local dev usage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,7 @@ bun run check            # biome check (lint + format)
 bun run fix              # biome auto-fix
 bun run lint             # lint only
 bun run format           # format only
+bun run loom <command>   # run the CLI from source (e.g. bun run loom ps)
 ```
 
 Default to using Bun instead of Node.js for all commands.

--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ bun run build
 
 ## CLI
 
+> **Local development:** use `bun run loom <command>` instead of `loom <command>` when running from the source repo. The `loom` binary is only available after installing the published npm package.
+
 Two primary commands cover the full lifecycle:
 
 ```sh

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "check": "biome check .",
     "fix": "biome check --write .",
     "format": "biome format --write .",
-    "lint": "biome lint ."
+    "lint": "biome lint .",
+    "loom": "bun packages/cli/src/main.ts"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.9",


### PR DESCRIPTION
## Summary

- Adds `"loom": "bun packages/cli/src/main.ts"` script to root `package.json` so the CLI can be run from source with `bun run loom <command>`
- Documents this in `CLAUDE.md` commands section
- Adds a local dev note to the `README.md` CLI section clarifying that `bun run loom <command>` is used in the source repo, while `loom` is only available after installing the published npm package

## Test plan

- [x] `bun run check` passes
- [x] `bun run build` passes
- [x] `bun test` passes