### PR TITLE
✨ feat(runner): implement resolveProvider() with prefix-based model routing

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -15,6 +15,21 @@
       "recommended": true
     }
   },
+  "overrides": [
+    {
+      "includes": ["**/*.test.ts"],
+      "linter": {
+        "rules": {
+          "style": {
+            "noNonNullAssertion": "off"
+          },
+          "suspicious": {
+            "noExplicitAny": "off"
+          }
+        }
+      }
+    }
+  ],
   "javascript": {
     "formatter": {
       "quoteStyle": "double",

--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -3,5 +3,7 @@ export {
   type ChatResponse,
   type Provider,
   ProviderRegistry,
+  type ResolvedProvider,
+  resolveProvider,
   type ToolCall,
 } from "./provider";

--- a/packages/runner/src/provider.test.ts
+++ b/packages/runner/src/provider.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { type Provider, ProviderRegistry } from "./provider";
+import { type Provider, ProviderRegistry, resolveProvider } from "./provider";
 
 test("register and get a provider", () => {
   const registry = new ProviderRegistry();
@@ -22,4 +22,60 @@ test("register overwrites existing provider", () => {
   registry.register("p", a);
   registry.register("p", b);
   expect(registry.get("p")).toBe(b);
+});
+
+// resolveProvider tests
+
+function makeRegistryWithStub(name: string): { registry: ProviderRegistry; stub: Provider } {
+  const registry = new ProviderRegistry();
+  const stub: Provider = { chat: async () => ({ text: "" }) };
+  registry.register(name, stub);
+  return { registry, stub };
+}
+
+test("resolveProvider: no prefix defaults to ollama", () => {
+  const { registry, stub } = makeRegistryWithStub("ollama");
+  const result = resolveProvider("llama3", registry);
+  expect(result.modelName).toBe("llama3");
+  expect(result.provider).toBe(stub);
+});
+
+test("resolveProvider: ollama/ prefix", () => {
+  const { registry, stub } = makeRegistryWithStub("ollama");
+  const result = resolveProvider("ollama/llama3", registry);
+  expect(result.modelName).toBe("llama3");
+  expect(result.provider).toBe(stub);
+});
+
+test("resolveProvider: anthropic/ prefix", () => {
+  const { registry, stub } = makeRegistryWithStub("anthropic");
+  const result = resolveProvider("anthropic/claude-3-5-sonnet", registry);
+  expect(result.modelName).toBe("claude-3-5-sonnet");
+  expect(result.provider).toBe(stub);
+});
+
+test("resolveProvider: openai/ prefix", () => {
+  const { registry, stub } = makeRegistryWithStub("openai");
+  const result = resolveProvider("openai/gpt-4o", registry);
+  expect(result.modelName).toBe("gpt-4o");
+  expect(result.provider).toBe(stub);
+});
+
+test("resolveProvider: openrouter/ prefix", () => {
+  const { registry, stub } = makeRegistryWithStub("openrouter");
+  const result = resolveProvider("openrouter/meta-llama/llama-3", registry);
+  expect(result.modelName).toBe("meta-llama/llama-3");
+  expect(result.provider).toBe(stub);
+});
+
+test("resolveProvider: unknown prefix throws", () => {
+  const { registry } = makeRegistryWithStub("ollama");
+  expect(() => resolveProvider("cohere/command-r", registry)).toThrow(
+    'Unknown provider prefix "cohere"',
+  );
+});
+
+test("resolveProvider: unregistered provider throws", () => {
+  const registry = new ProviderRegistry(); // empty — no ollama registered
+  expect(() => resolveProvider("llama3", registry)).toThrow('Provider "ollama" is not registered');
 });

--- a/packages/runner/src/provider.ts
+++ b/packages/runner/src/provider.ts
@@ -39,3 +39,42 @@ export class ProviderRegistry {
     return this.providers.get(name);
   }
 }
+
+const KNOWN_PREFIXES = ["ollama", "anthropic", "openai", "openrouter"] as const;
+
+/** Result of resolving a prefixed model string. */
+export interface ResolvedProvider {
+  provider: Provider;
+  modelName: string;
+}
+
+/**
+ * Resolve a (possibly prefixed) model string to a provider and bare model name.
+ * No prefix defaults to Ollama. Throws if the prefix is unknown or the provider is not registered.
+ */
+export function resolveProvider(model: string, registry: ProviderRegistry): ResolvedProvider {
+  const slashIdx = model.indexOf("/");
+  let providerName: string;
+  let modelName: string;
+
+  if (slashIdx === -1) {
+    providerName = "ollama";
+    modelName = model;
+  } else {
+    providerName = model.slice(0, slashIdx);
+    modelName = model.slice(slashIdx + 1);
+
+    if (!(KNOWN_PREFIXES as readonly string[]).includes(providerName)) {
+      throw new Error(
+        `Unknown provider prefix "${providerName}". Known prefixes: ${KNOWN_PREFIXES.join(", ")}`,
+      );
+    }
+  }
+
+  const provider = registry.get(providerName);
+  if (!provider) {
+    throw new Error(`Provider "${providerName}" is not registered`);
+  }
+
+  return { provider, modelName };
+}


### PR DESCRIPTION
## Summary
- Adds `resolveProvider(model, registry)` to `packages/runner/src/provider.ts` — parses model prefix, strips it, returns `{ provider, modelName }`
- No prefix defaults to Ollama; throws on unknown prefix or unregistered provider
- Exports `resolveProvider` and `ResolvedProvider` from `packages/runner/src/index.ts`
- Adds biome.json override to relax `noNonNullAssertion` and `noExplicitAny` in `*.test.ts` files

## Test plan
- `bun test --filter provider` — all 10 tests pass, covering all 4 prefixes, no-prefix default, unknown prefix error, and unregistered provider error
- `bun run build` — dual-target build + `tsc` declarations succeed for all packages
- `bun run check` — biome lint/format clean

Closes #19