### PR TITLE
✨ feat(runner): implement AgentRunner core loop (inbox → LLM → outbox)

### DIFF
--- a/docs/adrs/ADR-003-inbox-watcher-polling.md
+++ b/docs/adrs/ADR-003-inbox-watcher-polling.md
@@ -17,13 +17,10 @@ Options:
 
 Use polling at a configurable interval (default 200 ms).
 
-The implementation is split into two layers:
-
-- **`InboxWatcher`** — polls a single inbox directory, consumes `.msg` files, and
-  emits `(filename, message)` events. This is the low-level primitive.
-- **`InboxRouter`** — manages one `InboxWatcher` per agent, forwarding events with
-  the agent name prepended: `(agentName, filename, message)`. This is the multi-agent
-  coordinator.
+**`InboxWatcher`** polls a single inbox directory, validates `.msg` files, and emits
+`(filename)` events — one per new file. It does **not** move or consume files.
+Lifecycle management (`claim` / `acknowledge` / `fail`) is the responsibility of the
+consumer (the runner).
 
 ### Three-phase message lifecycle
 
@@ -47,18 +44,15 @@ inbox/
 ```
 InboxWatcher.poll()
   list *.msg files in inbox/ (sorted by filename → oldest first)
-  for each file:
-    read + parse JSON
-    emit('message', filename, message)
-
-InboxRouter.add(agent)
-  create InboxWatcher.forAgent(home, agent)
-  forward events with agent name prefix
-  start watcher
+  for each file not already seen:
+    read + validate JSON
+    if valid   → add to seen set, emit('message', filename)
+    if invalid → quarantine to .unreadable/, emit('error', err)
+  remove files from seen set that no longer exist in inbox/
 ```
 
 The watcher emits events; the **runner** (ADR-005) owns the three-phase
-transitions. When the runner receives a message event, it:
+transitions. When the runner receives a `message` event, it:
 
 1. Calls `claim()` — moves the file to `inbox/.in-progress/`
 2. Processes the message (LLM call, tool execution, writes response to `outbox/`)
@@ -112,16 +106,14 @@ so `ls inbox/` still gives a clean view of pending messages.
   for conversational agents. For tighter latency, callers can set `pollIntervalMs: 50`.
 - At high message volume, many small files accumulate in `.processed/`. A future
   compaction pass can archive these to NDJSON logs.
-- `InboxWatcher` extends `EventEmitter`, emits `(filename, message)`. Single-agent
-  callers (e.g. `AgentRunner`) use it directly via `InboxWatcher.forAgent(home, name)`.
-  Errors are surfaced via the standard `'error'` event.
-- `InboxRouter` manages multiple `InboxWatcher` instances, emits
-  `(agentName, filename, message)`. Multi-agent callers (e.g. supervisor) use it
-  via `router.add(agent)` / `router.remove(agent)` / `router.stop()`.
-- **`home` parameter convention:** `InboxWatcher.forAgent(home, name)` and
-  `InboxRouter` expect `home` to be the agents root directory
-  (`$LOOM_HOME/agents`), not `$LOOM_HOME` itself. The watcher constructs the
-  inbox path as `{home}/{name}/inbox/`.
+- `InboxWatcher` extends `EventEmitter`, emits `(filename)` — filename only, no
+  parsed message. The consumer calls `claim()` to read and take ownership.
+  Invalid files are quarantined to `.unreadable/` and surfaced via the `'error'` event.
+  A `seen` set prevents duplicate emissions across poll cycles; entries are removed
+  when the file leaves the inbox (claimed, moved, or deleted).
+- **`home` parameter convention:** `InboxWatcher.forAgent(home, name)` expects
+  `home` to be the agents root directory (`$LOOM_HOME/agents`), not `$LOOM_HOME`
+  itself. The watcher constructs the inbox path as `{home}/{name}/inbox/`.
 
 ---
 
@@ -132,3 +124,5 @@ so `ls inbox/` still gives a clean view of pending messages.
 | 2026-03-31 | **Removed "not yet implemented" note.** The three-phase lifecycle (claim → process → acknowledge) is the decided design, not a future target. |
 | 2026-03-31 | **Clarified watcher vs runner responsibility.** `InboxWatcher` detects and emits; the runner owns the claim/process/acknowledge transitions. Updated pseudocode to reflect this separation. |
 | 2026-03-31 | **Documented `home` parameter convention.** `home` is `$LOOM_HOME/agents`, not `$LOOM_HOME`. |
+| 2026-04-01 | **`InboxWatcher` is now notification-only.** It no longer calls `consume()`. It validates files, emits `(filename)` events, and quarantines invalid files. A `seen` set prevents duplicate emissions. Lifecycle transitions are fully delegated to the consumer. |
+| 2026-04-01 | **Removed `InboxRouter`.** It was never used — ADR-005 runners are self-sufficient and each polls its own inbox directly. There is no central message dispatcher. |

--- a/docs/adrs/ADR-005-runner-architecture.md
+++ b/docs/adrs/ADR-005-runner-architecture.md
@@ -71,6 +71,19 @@ The runner processes messages through three filesystem phases (see ADR-003):
 5. Move from .in-progress/ to .processed/  — "Done"
 ```
 
+### Sequential processing
+
+Messages are processed one at a time (FIFO). `InboxWatcher` may emit multiple
+filenames in a single poll cycle (all files found in inbox/). The runner uses an
+internal drain queue: filenames are enqueued on each `message` event and drained
+one at a time. This ensures only one LLM call is in flight per agent at any time
+and keeps status transitions (`running` / `idle`) consistent.
+
+### Outbox reply format
+
+Responses are written with `sendReply(root, agent, body, inReplyTo)`. The `from`
+field is always the agent's own name — no separate `from` parameter is needed.
+
 ### Idempotent restart recovery
 
 On startup, the runner checks `inbox/.in-progress/` for messages that were
@@ -193,3 +206,5 @@ and tight coupling to the supervisor. Rejected.
 | Date | Change |
 |---|---|
 | 2026-03-31 | **Removed dangling "plugin protocol ADR" reference.** The tool execution protocol is described inline in this ADR. A separate plugin protocol ADR may be added in the future if the protocol warrants its own decision record. |
+| 2026-04-01 | **Added sequential processing.** The runner uses a drain queue to ensure FIFO, one-at-a-time message processing. Only one LLM call is in flight per agent at any time. |
+| 2026-04-01 | **`sendReply` drops the `from` parameter.** Replies always originate from the agent itself; `from` is derived from `agent` internally. |

--- a/packages/runner/src/agent-runner.test.ts
+++ b/packages/runner/src/agent-runner.test.ts
@@ -1,0 +1,207 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { mkdtemp, readdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { AgentProcess, list, read, send } from "@losoft/loom-runtime";
+import { AgentRunner } from "./agent-runner";
+import { type Provider, ProviderRegistry } from "./provider";
+
+let home: string;
+
+beforeEach(async () => {
+  home = await mkdtemp(join(tmpdir(), "loom-runner-test-"));
+});
+
+afterEach(async () => {
+  await rm(home, { recursive: true, force: true });
+});
+
+function makeRegistry(response: string): ProviderRegistry {
+  const registry = new ProviderRegistry();
+  const provider: Provider = { chat: async () => ({ text: response }) };
+  registry.register("ollama", provider);
+  return registry;
+}
+
+/** Poll until outboxDir has at least one .msg file, or throw on timeout. */
+async function waitForOutbox(outboxDir: string, timeout = 2000): Promise<string[]> {
+  const deadline = Date.now() + timeout;
+  while (Date.now() < deadline) {
+    const files = await list(outboxDir);
+    if (files.length > 0) return files;
+    await new Promise<void>((r) => setTimeout(r, 10));
+  }
+  throw new Error("Timed out waiting for outbox message");
+}
+
+/** Poll until the agent's status file matches the expected value. */
+async function waitForStatus(agent: AgentProcess, status: string, timeout = 2000): Promise<void> {
+  const deadline = Date.now() + timeout;
+  while (Date.now() < deadline) {
+    if (agent.status === status) return;
+    await new Promise<void>((r) => setTimeout(r, 10));
+  }
+  throw new Error(`Timed out waiting for status "${status}" (current: "${agent.status}")`);
+}
+
+const AGENT = "alice";
+
+test("processes a message end-to-end and writes outbox reply", async () => {
+  const agent = new AgentProcess(home, AGENT);
+  agent.model = "ollama/llama3";
+
+  await send(home, AGENT, "user", "hello");
+
+  const runner = new AgentRunner(home, AGENT, makeRegistry("world"), { pollIntervalMs: 20 });
+  const runPromise = runner.run();
+
+  const outboxDir = join(home, AGENT, "outbox");
+  const outboxFiles = await waitForOutbox(outboxDir);
+  runner.stop();
+  await runPromise;
+
+  expect(outboxFiles).toHaveLength(1);
+  const reply = await read(outboxDir, outboxFiles[0]!);
+  expect(reply.body).toBe("world");
+  expect(reply.from).toBe(AGENT);
+});
+
+test("reply includes in_reply_to referencing the inbox filename", async () => {
+  new AgentProcess(home, AGENT);
+
+  const inboxMsg = await send(home, AGENT, "user", "ping");
+
+  const runner = new AgentRunner(home, AGENT, makeRegistry("pong"), { pollIntervalMs: 20 });
+  const runPromise = runner.run();
+
+  const outboxDir = join(home, AGENT, "outbox");
+  const outboxFiles = await waitForOutbox(outboxDir);
+  runner.stop();
+  await runPromise;
+
+  const reply = await read(outboxDir, outboxFiles[0]!);
+  expect(reply.in_reply_to).toContain(inboxMsg.id);
+});
+
+test("message moves from inbox to .processed after handling", async () => {
+  new AgentProcess(home, AGENT);
+  await send(home, AGENT, "user", "test");
+
+  const runner = new AgentRunner(home, AGENT, makeRegistry("ok"), { pollIntervalMs: 20 });
+  const runPromise = runner.run();
+
+  await waitForOutbox(join(home, AGENT, "outbox"));
+  runner.stop();
+  await runPromise;
+
+  const inboxDir = join(home, AGENT, "inbox");
+  expect(await list(inboxDir)).toHaveLength(0);
+
+  const processedFiles = await readdir(join(inboxDir, ".processed"));
+  expect(processedFiles.filter((f) => f.endsWith(".msg"))).toHaveLength(1);
+});
+
+test("status transitions idle -> running -> idle", async () => {
+  let capturedStatusDuringChat: string | undefined;
+  const registry = new ProviderRegistry();
+  registry.register("ollama", {
+    chat: async () => {
+      capturedStatusDuringChat = agent.status;
+      return { text: "reply" };
+    },
+  } satisfies Provider);
+
+  const runner = new AgentRunner(home, AGENT, registry, { pollIntervalMs: 20 });
+  const agent = new AgentProcess(home, AGENT); // shared filesystem state with runner's internal agent
+  await send(home, AGENT, "user", "hi");
+  const runPromise = runner.run();
+
+  // Wait for the outbox reply to appear (chat was called), then wait for idle (acknowledge done)
+  await waitForOutbox(join(home, AGENT, "outbox"));
+  await waitForStatus(agent, "idle");
+  runner.stop();
+  await runPromise;
+
+  expect(capturedStatusDuringChat).toBe("running");
+  expect(agent.status).toBe("idle");
+});
+
+test("processes multiple messages in FIFO order", async () => {
+  new AgentProcess(home, AGENT);
+  await send(home, AGENT, "user", "first");
+  await new Promise<void>((r) => setTimeout(r, 5)); // ensure different timestamps
+  await send(home, AGENT, "user", "second");
+
+  const received: string[] = [];
+  const registry = new ProviderRegistry();
+  registry.register("ollama", {
+    chat: async (_model, _system, messages) => {
+      received.push(messages[0]!.content);
+      return { text: "ok" };
+    },
+  } satisfies Provider);
+
+  const runner = new AgentRunner(home, AGENT, registry, { pollIntervalMs: 20 });
+  const runPromise = runner.run();
+
+  const outboxDir = join(home, AGENT, "outbox");
+  // wait for both messages
+  const deadline = Date.now() + 2000;
+  while (Date.now() < deadline) {
+    const files = await list(outboxDir);
+    if (files.length >= 2) break;
+    await new Promise<void>((r) => setTimeout(r, 10));
+  }
+  runner.stop();
+  await runPromise;
+
+  expect(received).toEqual(["first", "second"]);
+});
+
+test("messages arriving in the same poll cycle are processed sequentially, not concurrently", async () => {
+  const starts: number[] = [];
+  const ends: number[] = [];
+  const registry = new ProviderRegistry();
+  registry.register("ollama", {
+    chat: async () => {
+      starts.push(Date.now());
+      await new Promise<void>((r) => setTimeout(r, 30)); // simulate slow LLM
+      ends.push(Date.now());
+      return { text: "ok" };
+    },
+  } satisfies Provider);
+
+  // Create runner first (constructor creates inbox directory), then enqueue both messages
+  // before calling run() so they land in the first poll cycle.
+  const serialRunner = new AgentRunner(home, AGENT, registry, { pollIntervalMs: 20 });
+  await send(home, AGENT, "user", "first");
+  await send(home, AGENT, "user", "second");
+  const runPromise = serialRunner.run();
+
+  const outboxDir = join(home, AGENT, "outbox");
+  const deadline = Date.now() + 3000;
+  while (Date.now() < deadline) {
+    const files = await list(outboxDir);
+    if (files.length >= 2) break;
+    await new Promise<void>((r) => setTimeout(r, 10));
+  }
+  serialRunner.stop();
+  await runPromise;
+
+  // Second message must not start before first message ends
+  expect(starts).toHaveLength(2);
+  expect(ends).toHaveLength(2);
+  expect(starts[1]!).toBeGreaterThanOrEqual(ends[0]!);
+});
+
+test("stop() halts the polling loop", async () => {
+  new AgentProcess(home, AGENT);
+
+  const runner = new AgentRunner(home, AGENT, makeRegistry("x"), { pollIntervalMs: 20 });
+  const runPromise = runner.run();
+  runner.stop();
+  await runPromise; // should resolve promptly
+
+  // No messages were sent — outbox should be empty
+  expect(await list(join(home, AGENT, "outbox"))).toHaveLength(0);
+});

--- a/packages/runner/src/agent-runner.ts
+++ b/packages/runner/src/agent-runner.ts
@@ -1,0 +1,95 @@
+import { join } from "node:path";
+import { AgentProcess, acknowledge, claim, InboxWatcher, sendReply } from "@losoft/loom-runtime";
+import { type ProviderRegistry, resolveProvider } from "./provider";
+
+export interface AgentRunnerOptions {
+  /** Polling interval in milliseconds (default 200). */
+  pollIntervalMs?: number;
+  /** System prompt sent to the LLM on every turn. */
+  systemPrompt?: string;
+}
+
+/**
+ * Manages a single agent's message loop: polls inbox, calls LLM, writes outbox replies.
+ *
+ * Messages are processed strictly sequentially (FIFO). A drain queue ensures that
+ * even if multiple messages arrive in one poll cycle, only one LLM call is in flight
+ * at a time.
+ *
+ * Uses the three-phase message lifecycle (inbox → .in-progress → .processed) so that
+ * in-flight messages are recoverable after a crash.
+ */
+export class AgentRunner {
+  private readonly agent: AgentProcess;
+  private readonly watcher: InboxWatcher;
+  private readonly inboxDir: string;
+  private readonly systemPrompt: string;
+  private readonly queue: string[] = [];
+  private draining = false;
+  private resolveRun: (() => void) | null = null;
+
+  constructor(
+    /** Agents root directory — $LOOM_HOME/agents. */
+    private readonly home: string,
+    private readonly agentName: string,
+    private readonly registry: ProviderRegistry,
+    options?: AgentRunnerOptions,
+  ) {
+    this.agent = new AgentProcess(home, agentName);
+    this.inboxDir = join(home, agentName, "inbox");
+    this.systemPrompt = options?.systemPrompt ?? "";
+    this.watcher = InboxWatcher.forAgent(home, agentName, {
+      pollIntervalMs: options?.pollIntervalMs,
+    });
+
+    this.watcher.on("message", (filename) => {
+      this.queue.push(filename);
+      this.drain();
+    });
+  }
+
+  /** Process queued messages one at a time (FIFO). */
+  private async drain(): Promise<void> {
+    if (this.draining) return;
+    this.draining = true;
+    try {
+      while (this.queue.length > 0) {
+        const filename = this.queue.shift();
+        if (filename !== undefined) await this.processMessage(filename);
+      }
+    } finally {
+      this.draining = false;
+    }
+  }
+
+  /** Process a single message: claim → LLM → reply → acknowledge. */
+  private async processMessage(filename: string): Promise<void> {
+    const message = await claim(this.inboxDir, filename);
+    this.agent.status = "running";
+
+    const { provider, modelName } = resolveProvider(this.agent.model, this.registry);
+    const response = await provider.chat(modelName, this.systemPrompt, [
+      { role: "user", content: message.body },
+    ]);
+
+    await sendReply(this.home, this.agentName, response.text, filename);
+    await acknowledge(this.inboxDir, filename);
+    this.agent.status = "idle";
+  }
+
+  /** Start the agent loop. Returns a Promise that resolves when stop() is called. */
+  run(): Promise<void> {
+    this.agent.status = "idle";
+    this.watcher.start();
+    return new Promise<void>((resolve) => {
+      this.resolveRun = resolve;
+    });
+  }
+
+  /** Stop the polling loop. */
+  stop(): void {
+    this.watcher.stop();
+    this.resolveRun?.();
+    this.resolveRun = null;
+  }
+}

--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -1,3 +1,4 @@
+export { AgentRunner, type AgentRunnerOptions } from "./agent-runner";
 export {
   type ChatMessage,
   type ChatResponse,

--- a/packages/runtime/src/inbox-watcher.test.ts
+++ b/packages/runtime/src/inbox-watcher.test.ts
@@ -15,7 +15,6 @@ beforeEach(() => {
 
 afterEach(async () => {
   watcher.stop();
-  // Allow any in-flight poll to settle before removing the directory.
   await Bun.sleep(10);
   rmSync(inbox, { recursive: true, force: true });
 });
@@ -39,11 +38,9 @@ test("stop is safe to call when not running", () => {
   expect(() => watcher.stop()).not.toThrow();
 });
 
-test("emits message with filename and parsed content for .msg files", async () => {
-  const received = new Promise<{ filename: string; message: Message }>((resolve) => {
-    watcher.on("message", (filename, message) => {
-      resolve({ filename, message });
-    });
+test("emits message with filename when a valid .msg file appears", async () => {
+  const received = new Promise<string>((resolve) => {
+    watcher.on("message", (filename) => resolve(filename));
   });
 
   watcher.start();
@@ -51,32 +48,11 @@ test("emits message with filename and parsed content for .msg files", async () =
   const msg: Message = { v: 1, id: "abc123", from: "test", ts: Date.now(), body: "hello" };
   await Bun.file(join(inbox, "123-abc.msg")).write(JSON.stringify(msg));
 
-  const event = await received;
-  expect(event.filename).toBe("123-abc.msg");
-  expect(event.message.id).toBe("abc123");
-  expect(event.message.body).toBe("hello");
+  const filename = await received;
+  expect(filename).toBe("123-abc.msg");
 });
 
-test("ignores non-.msg files", async () => {
-  const messages: string[] = [];
-
-  watcher.on("message", (filename) => {
-    messages.push(filename);
-  });
-
-  watcher.start();
-
-  await Bun.file(join(inbox, "notes.txt")).write("not a message");
-  await Bun.sleep(150);
-
-  expect(messages).toEqual([]);
-});
-
-test("inbox is set from constructor", () => {
-  expect(watcher.inbox).toBe(inbox);
-});
-
-test("moves consumed messages to .processed/", async () => {
+test("does not move the file after emitting (consumer is responsible)", async () => {
   const received = new Promise<void>((resolve) => {
     watcher.on("message", () => resolve());
   });
@@ -88,8 +64,35 @@ test("moves consumed messages to .processed/", async () => {
 
   await received;
 
-  expect(existsSync(join(inbox, "100-def.msg"))).toBe(false);
-  expect(existsSync(join(inbox, ".processed", "100-def.msg"))).toBe(true);
+  expect(existsSync(join(inbox, "100-def.msg"))).toBe(true);
+  expect(existsSync(join(inbox, ".processed", "100-def.msg"))).toBe(false);
+});
+
+test("does not emit the same file twice", async () => {
+  const filenames: string[] = [];
+  watcher.on("message", (f) => filenames.push(f));
+
+  watcher.start();
+
+  const msg: Message = { v: 1, id: "dup1", from: "test", ts: Date.now(), body: "dup" };
+  await Bun.file(join(inbox, "200-dup.msg")).write(JSON.stringify(msg));
+
+  // Wait for several poll cycles
+  await Bun.sleep(200);
+
+  expect(filenames).toEqual(["200-dup.msg"]);
+});
+
+test("ignores non-.msg files", async () => {
+  const messages: string[] = [];
+  watcher.on("message", (f) => messages.push(f));
+
+  watcher.start();
+
+  await Bun.file(join(inbox, "notes.txt")).write("not a message");
+  await Bun.sleep(150);
+
+  expect(messages).toEqual([]);
 });
 
 test("emits error and quarantines invalid message files", async () => {
@@ -103,8 +106,6 @@ test("emits error and quarantines invalid message files", async () => {
 
   const err = await received;
   expect(err).toBeInstanceOf(Error);
-
-  // File should be moved to .unreadable/, not left in inbox
   expect(existsSync(join(inbox, "bad.msg"))).toBe(false);
   expect(existsSync(join(inbox, ".unreadable", "bad.msg"))).toBe(true);
 });
@@ -117,10 +118,8 @@ test("invalid file does not cause repeated errors", async () => {
 
   await Bun.file(join(inbox, "bad.msg")).write("not json");
 
-  // Wait for several poll cycles
   await Bun.sleep(200);
 
-  // Should only have errored once (file was quarantined on first encounter)
   expect(errors).toHaveLength(1);
 });
 
@@ -139,7 +138,6 @@ test("processes messages in FIFO order (sorted by filename)", async () => {
     { v: 1 as const, id: "c", from: "test", ts: 3, body: "third" },
   ];
 
-  // Write files before starting so they're all picked up in one poll
   for (const msg of msgs) {
     await Bun.file(join(inbox, `${msg.ts}-${msg.id}.msg`)).write(JSON.stringify(msg));
   }
@@ -148,6 +146,30 @@ test("processes messages in FIFO order (sorted by filename)", async () => {
   await allReceived;
 
   expect(filenames).toEqual(["1-a.msg", "2-b.msg", "3-c.msg"]);
+});
+
+test("re-emits a filename after it has been removed and a new file with the same name appears", async () => {
+  const filenames: string[] = [];
+  watcher.on("message", (f) => filenames.push(f));
+
+  watcher.start();
+
+  const msg: Message = { v: 1, id: "x1", from: "test", ts: 1, body: "a" };
+  await Bun.file(join(inbox, "1-x.msg")).write(JSON.stringify(msg));
+  await Bun.sleep(100);
+
+  // Simulate consumer claiming the file (removes it from inbox)
+  const { rename } = await import("node:fs/promises");
+  const { mkdir } = await import("node:fs/promises");
+  await mkdir(join(inbox, ".in-progress"), { recursive: true });
+  await rename(join(inbox, "1-x.msg"), join(inbox, ".in-progress", "1-x.msg"));
+  await Bun.sleep(100);
+
+  // Write the same filename again (edge case)
+  await Bun.file(join(inbox, "1-x.msg")).write(JSON.stringify(msg));
+  await Bun.sleep(100);
+
+  expect(filenames).toEqual(["1-x.msg", "1-x.msg"]);
 });
 
 test("forAgent creates watcher for agent inbox path", () => {

--- a/packages/runtime/src/inbox-watcher.ts
+++ b/packages/runtime/src/inbox-watcher.ts
@@ -1,16 +1,18 @@
 /**
- * @file Inbox directory watcher that emits parsed messages when new `.msg` files appear.
+ * @file Inbox directory watcher that notifies when new `.msg` files appear.
  * @module @loom/runtime/inbox-watcher
  *
  * Polls a given inbox directory at a configurable interval (default 200 ms).
- * When `.msg` files are found, they are read, parsed, moved to `.processed/`,
- * and emitted as `message` events. The timer is unref'd so it does not prevent
+ * When new `.msg` files are found they are validated and emitted as `message`
+ * events. Files are NOT moved — lifecycle management (claim / acknowledge /
+ * fail) is the responsibility of the consumer. Invalid files are quarantined
+ * and emitted as `error` events. The timer is unref'd so it does not prevent
  * the process from exiting.
  */
 
 import { EventEmitter } from "node:events";
 import { join } from "node:path";
-import { consume, list, type Message, quarantine } from "./message";
+import { list, quarantine, read } from "./message";
 
 export interface InboxWatcherOptions {
   /** Polling interval in milliseconds (default 200). */
@@ -18,21 +20,22 @@ export interface InboxWatcherOptions {
 }
 
 interface InboxWatcherEventMap {
-  message: [filename: string, message: Message];
+  message: [filename: string];
   error: [error: Error];
 }
 
 /**
- * Polls an inbox directory for new `.msg` files, reads and parses them,
- * moves them to `.processed/`, and emits a `message` event with the
- * filename and parsed {@link Message}.
+ * Polls an inbox directory for new `.msg` files, validates them, and emits a
+ * `message` event with the filename. Files are not moved — the consumer is
+ * responsible for calling `claim()` / `acknowledge()` / `fail()`.
  *
- * @fires message When a new `.msg` file is consumed from the inbox directory.
- * @fires error When a file cannot be read or parsed.
+ * @fires message When a new valid `.msg` file is detected in the inbox.
+ * @fires error When a file cannot be read or parsed; the file is quarantined.
  */
 export class InboxWatcher extends EventEmitter<InboxWatcherEventMap> {
-  private timer: Timer | null = null;
+  private timer: ReturnType<typeof setInterval> | null = null;
   private polling = false;
+  private readonly seen = new Set<string>();
   readonly inbox: string;
   readonly pollIntervalMs: number;
 
@@ -42,17 +45,26 @@ export class InboxWatcher extends EventEmitter<InboxWatcherEventMap> {
     this.pollIntervalMs = options?.pollIntervalMs ?? 200;
   }
 
-  /** Runs a single poll cycle: list, consume, and emit for each `.msg` file. */
+  /** Runs a single poll cycle: detect new files, validate, emit. */
   private async poll(): Promise<void> {
     if (this.polling || !this.timer) return;
     this.polling = true;
     try {
       const files = await list(this.inbox);
+
+      // Remove files that have left the inbox (claimed, moved, etc.)
+      for (const filename of this.seen) {
+        if (!files.includes(filename)) {
+          this.seen.delete(filename);
+        }
+      }
+
       for (const filename of files) {
-        if (!this.timer) break;
+        if (this.seen.has(filename)) continue;
         try {
-          const message = await consume(this.inbox, filename);
-          this.emit("message", filename, message);
+          await read(this.inbox, filename);
+          this.seen.add(filename);
+          this.emit("message", filename);
         } catch (err) {
           await quarantine(this.inbox, filename);
           this.emit("error", err instanceof Error ? err : new Error(String(err)));

--- a/packages/runtime/src/message.test.ts
+++ b/packages/runtime/src/message.test.ts
@@ -176,10 +176,10 @@ test("sendReply writes outbox message with in_reply_to", async () => {
   const outboxDir = join(root, AGENT, "outbox");
   mkdirSync(outboxDir, { recursive: true });
 
-  const msg = await sendReply(root, AGENT, "runner", "reply body", "1234-abcd.msg");
+  const msg = await sendReply(root, AGENT, "reply body", "1234-abcd.msg");
 
   expect(msg.in_reply_to).toBe("1234-abcd.msg");
-  expect(msg.from).toBe("runner");
+  expect(msg.from).toBe(AGENT);
   expect(msg.body).toBe("reply body");
 
   const files = await list(outboxDir);

--- a/packages/runtime/src/message.ts
+++ b/packages/runtime/src/message.ts
@@ -44,14 +44,20 @@ export function send(root: string, agent: string, from: string, body: string): P
 export function sendReply(
   root: string,
   agent: string,
-  from: string,
   body: string,
   inReplyTo: string,
 ): Promise<Message> {
   const id = generateId();
   const ts = Date.now();
 
-  const message: Message = { v: MESSAGE_VERSION, id, from, ts, body, in_reply_to: inReplyTo };
+  const message: Message = {
+    v: MESSAGE_VERSION,
+    id,
+    from: agent,
+    ts,
+    body,
+    in_reply_to: inReplyTo,
+  };
 
   const path = join(root, agent, "outbox", `${ts}-${id}.msg`);
   return Bun.file(path)


### PR DESCRIPTION
## Summary
- Adds `AgentRunner` class to `packages/runner` — polls inbox, calls LLM, writes outbox replies
- FIFO drain queue ensures only one LLM call is in flight per agent at a time; parallel processing is not allowed
- `InboxWatcher` refactored to notification-only: validates files, emits `(filename)`, never moves them — lifecycle transitions (`claim`/`acknowledge`/`fail`) are fully delegated to the consumer
- `sendReply` drops the redundant `from` parameter — always uses the agent name
- Removes `InboxRouter` — unused and inconsistent with the self-sufficient runner model
- Updates ADR-003 and ADR-005 to reflect all architectural decisions

## Test plan
- [x] `bun test --filter agent-runner` — 7 tests covering: end-to-end message flow, `in_reply_to` linking, three-phase file lifecycle, status transitions (`idle`→`running`→`idle`), FIFO ordering, sequential (non-concurrent) processing, and `stop()` behaviour
- [x] `bun test --filter inbox-watcher` — 14 tests covering: notification-only behaviour (file not moved), no duplicate emissions, quarantine on invalid files, FIFO ordering, re-emit after file removed
- [x] `bun test` — 93 tests pass across all packages
- [x] `bun run build` — dual-target build + `tsc` declarations succeed for all packages
- [x] `bun run check` — biome lint/format clean

Closes #20