### PR TITLE
✨ feat(runner): add idempotent restart recovery to AgentRunner

### DIFF
--- a/packages/runner/src/agent-runner.test.ts
+++ b/packages/runner/src/agent-runner.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, expect, test } from "bun:test";
 import { mkdtemp, readdir, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { AgentProcess, list, read, send } from "@losoft/loom-runtime";
+import { AgentProcess, claim, list, read, send, sendReply } from "@losoft/loom-runtime";
 import { AgentRunner } from "./agent-runner";
 import { type Provider, ProviderRegistry } from "./provider";
 
@@ -192,6 +192,68 @@ test("messages arriving in the same poll cycle are processed sequentially, not c
   expect(starts).toHaveLength(2);
   expect(ends).toHaveLength(2);
   expect(starts[1]!).toBeGreaterThanOrEqual(ends[0]!);
+});
+
+test("recover: skips already-replied in-progress message, no duplicate LLM call", async () => {
+  new AgentProcess(home, AGENT);
+  const inboxMsg = await send(home, AGENT, "user", "pre-crash");
+  const inboxDir = join(home, AGENT, "inbox");
+  const inboxFiles = await list(inboxDir);
+  const filename = inboxFiles[0]!;
+
+  // Simulate crash state: message was claimed and reply was written, but not acknowledged
+  await claim(inboxDir, filename);
+  await sendReply(home, AGENT, "pre-crash reply", filename);
+
+  let callCount = 0;
+  const registry = new ProviderRegistry();
+  registry.register("ollama", {
+    chat: async () => {
+      callCount++;
+      return { text: "should not be called" };
+    },
+  } satisfies Provider);
+
+  const runner = new AgentRunner(home, AGENT, registry, { pollIntervalMs: 20 });
+  const runPromise = runner.run();
+
+  // Wait a couple of poll cycles then stop
+  await new Promise<void>((r) => setTimeout(r, 80));
+  runner.stop();
+  await runPromise;
+
+  expect(callCount).toBe(0);
+  const outboxFiles = await list(join(home, AGENT, "outbox"));
+  expect(outboxFiles).toHaveLength(1);
+  const reply = await read(join(home, AGENT, "outbox"), outboxFiles[0]!);
+  expect(reply.in_reply_to).toContain(inboxMsg.id);
+  expect(await list(inboxDir)).toHaveLength(0);
+});
+
+test("recover: reprocesses in-progress message that has no outbox reply", async () => {
+  new AgentProcess(home, AGENT);
+  await send(home, AGENT, "user", "unfinished");
+  const inboxDir = join(home, AGENT, "inbox");
+  const inboxFiles = await list(inboxDir);
+  const filename = inboxFiles[0]!;
+
+  // Simulate crash state: message was claimed but runner crashed before writing the reply
+  await claim(inboxDir, filename);
+
+  const runner = new AgentRunner(home, AGENT, makeRegistry("recovered reply"), {
+    pollIntervalMs: 20,
+  });
+  const runPromise = runner.run();
+
+  const outboxDir = join(home, AGENT, "outbox");
+  const outboxFiles = await waitForOutbox(outboxDir);
+  runner.stop();
+  await runPromise;
+
+  expect(outboxFiles).toHaveLength(1);
+  const reply = await read(outboxDir, outboxFiles[0]!);
+  expect(reply.body).toBe("recovered reply");
+  expect(await list(inboxDir)).toHaveLength(0);
 });
 
 test("stop() halts the polling loop", async () => {

--- a/packages/runner/src/agent-runner.ts
+++ b/packages/runner/src/agent-runner.ts
@@ -1,5 +1,12 @@
 import { join } from "node:path";
-import { AgentProcess, acknowledge, claim, InboxWatcher, sendReply } from "@losoft/loom-runtime";
+import {
+  AgentProcess,
+  acknowledge,
+  claim,
+  InboxWatcher,
+  recover,
+  sendReply,
+} from "@losoft/loom-runtime";
 import { type ProviderRegistry, resolveProvider } from "./provider";
 
 export interface AgentRunnerOptions {
@@ -27,6 +34,7 @@ export class AgentRunner {
   private readonly queue: string[] = [];
   private draining = false;
   private resolveRun: (() => void) | null = null;
+  private stopped = false;
 
   constructor(
     /** Agents root directory — $LOOM_HOME/agents. */
@@ -78,8 +86,10 @@ export class AgentRunner {
   }
 
   /** Start the agent loop. Returns a Promise that resolves when stop() is called. */
-  run(): Promise<void> {
+  async run(): Promise<void> {
     this.agent.status = "idle";
+    await recover(this.inboxDir, join(this.home, this.agentName, "outbox"));
+    if (this.stopped) return;
     this.watcher.start();
     return new Promise<void>((resolve) => {
       this.resolveRun = resolve;
@@ -88,6 +98,7 @@ export class AgentRunner {
 
   /** Stop the polling loop. */
   stop(): void {
+    this.stopped = true;
     this.watcher.stop();
     this.resolveRun?.();
     this.resolveRun = null;

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -13,6 +13,7 @@ export {
   type Message,
   quarantine,
   read,
+  recover,
   send,
   sendReply,
 } from "./message";

--- a/packages/runtime/src/message.test.ts
+++ b/packages/runtime/src/message.test.ts
@@ -11,6 +11,7 @@ import {
   list,
   quarantine,
   read,
+  recover,
   send,
   sendReply,
 } from "./message";
@@ -244,6 +245,52 @@ test("fail writes companion .error.json", async () => {
   expect(await errorFile.exists()).toBe(true);
   const parsed = await errorFile.json();
   expect(parsed).toEqual(errorInfo);
+});
+
+// --- recover ---
+
+test("recover is a no-op when .in-progress is empty", async () => {
+  const inboxDir = join(root, AGENT, "inbox");
+  const outboxDir = join(root, AGENT, "outbox");
+  mkdirSync(outboxDir, { recursive: true });
+
+  await recover(inboxDir, outboxDir); // should not throw
+});
+
+test("recover acknowledges an in-progress message whose reply is already in outbox", async () => {
+  const inboxDir = join(root, AGENT, "inbox");
+  const outboxDir = join(root, AGENT, "outbox");
+  mkdirSync(outboxDir, { recursive: true });
+
+  await send(root, AGENT, "user", "hello");
+  const files = await list(inboxDir);
+  const filename = files[0]!;
+
+  await claim(inboxDir, filename);
+  await sendReply(root, AGENT, "reply", filename);
+
+  await recover(inboxDir, outboxDir);
+
+  expect(await Bun.file(join(inboxDir, ".in-progress", filename)).exists()).toBe(false);
+  expect(await Bun.file(join(inboxDir, ".processed", filename)).exists()).toBe(true);
+  expect(await list(inboxDir)).toHaveLength(0);
+});
+
+test("recover moves an in-progress message back to inbox when no reply exists", async () => {
+  const inboxDir = join(root, AGENT, "inbox");
+  const outboxDir = join(root, AGENT, "outbox");
+  mkdirSync(outboxDir, { recursive: true });
+
+  await send(root, AGENT, "user", "hello");
+  const files = await list(inboxDir);
+  const filename = files[0]!;
+
+  await claim(inboxDir, filename);
+
+  await recover(inboxDir, outboxDir);
+
+  expect(await Bun.file(join(inboxDir, ".in-progress", filename)).exists()).toBe(false);
+  expect(await list(inboxDir)).toEqual([filename]);
 });
 
 // --- quarantine ---

--- a/packages/runtime/src/message.ts
+++ b/packages/runtime/src/message.ts
@@ -153,6 +153,35 @@ export async function consume(dir: string, filename: string): Promise<Message> {
   return msg;
 }
 
+/**
+ * Recover in-progress messages left by a previous crash.
+ *
+ * For each file in `inboxDir/.in-progress/`:
+ * - If `outboxDir` has a reply with matching `in_reply_to` → acknowledge (move to `.processed/`).
+ * - Otherwise → move back to `inboxDir` for reprocessing.
+ */
+export async function recover(inboxDir: string, outboxDir: string): Promise<void> {
+  const inProgressDir = join(inboxDir, ".in-progress");
+
+  const inProgressFiles = await list(inProgressDir);
+  if (inProgressFiles.length === 0) return;
+
+  const outboxFiles = await list(outboxDir);
+  const repliedTo = new Set<string>();
+  for (const f of outboxFiles) {
+    const msg = await read(outboxDir, f);
+    if (msg.in_reply_to) repliedTo.add(msg.in_reply_to);
+  }
+
+  for (const filename of inProgressFiles) {
+    if (repliedTo.has(filename)) {
+      await acknowledge(inboxDir, filename);
+    } else {
+      await rename(join(inProgressDir, filename), join(inboxDir, filename));
+    }
+  }
+}
+
 export interface FailError {
   ts: string;
   attempts: number;


### PR DESCRIPTION
## Summary

- Add `recover(inboxDir, outboxDir)` to `@losoft/loom-runtime` — scans `inbox/.in-progress/` on startup, acknowledges messages that already have an outbox reply, and requeues the rest
- Call `recover()` in `AgentRunner.run()` before starting the inbox watcher, providing at-least-once delivery with no duplicate responses (ADR-005)
- Add `stopped` flag so `stop()` called during recovery still resolves the run promise correctly

## Test plan

- [x] `bun test --filter message` — 3 new unit tests for `recover()`: no-op when empty, acknowledges already-replied message, requeues incomplete message
- [x] `bun test --filter agent-runner` — 2 new integration tests simulating crash scenarios:
  - [x] Crash-after-reply: verifies `recover()` acknowledges the in-progress message and zero duplicate LLM calls are made
  - [x] Crash-before-reply: verifies the message is moved back to inbox, reprocessed, and the outbox reply is written
- [x] All 98 tests pass, `bun run check` clean

Closes #21