### PR TITLE
♻️ refactor(runtime): replace in_reply_to with origin + error fields

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -54,11 +54,11 @@ Messages are JSON files named `{timestamp_ms}-{id}.msg`. Three-phase lifecycle:
 2. **Claimed** — `claim()` atomically moves file to `inbox/.in-progress/`
 3. **Done** — `acknowledge()` moves to `inbox/.processed/`; or `fail()` moves to `inbox/.failed/` with a companion `.error.json`
 
-`recover(inboxDir, outboxDir)` handles crash recovery: re-queues in-progress messages unless the outbox already has a reply with a matching `in_reply_to`.
+`recover(inboxDir, outboxDir)` handles crash recovery: re-queues in-progress messages unless the outbox already has a reply whose `origin` path's last segment matches the in-progress filename.
 
 ### `AgentRunner` message loop
 
-Processes messages strictly FIFO, one at a time. Claims a message, calls the LLM via `resolveProvider()`, writes a reply to `outbox/` via `sendReply()` (sets `in_reply_to` for crash recovery), then acknowledges.
+Processes messages strictly FIFO, one at a time. Claims a message, calls the LLM via `resolveProvider()`, writes a reply to `outbox/` via `sendReply()` (builds `origin` path for pipeline tracing and crash recovery), then acknowledges.
 
 ### Model string format
 

--- a/packages/runner/src/agent-runner.test.ts
+++ b/packages/runner/src/agent-runner.test.ts
@@ -66,7 +66,7 @@ test("processes a message end-to-end and writes outbox reply", async () => {
   expect(reply.from).toBe(AGENT);
 });
 
-test("reply includes in_reply_to referencing the inbox filename", async () => {
+test("reply includes origin referencing the inbox filename", async () => {
   new AgentProcess(home, AGENT);
 
   const inboxMsg = await send(home, AGENT, "user", "ping");
@@ -80,7 +80,7 @@ test("reply includes in_reply_to referencing the inbox filename", async () => {
   await runPromise;
 
   const reply = await read(outboxDir, outboxFiles[0]!);
-  expect(reply.in_reply_to).toContain(inboxMsg.id);
+  expect(reply.origin).toContain(inboxMsg.id);
 });
 
 test("message moves from inbox to .processed after handling", async () => {
@@ -226,7 +226,7 @@ test("recover: skips already-replied in-progress message, no duplicate LLM call"
   const outboxFiles = await list(join(home, AGENT, "outbox"));
   expect(outboxFiles).toHaveLength(1);
   const reply = await read(join(home, AGENT, "outbox"), outboxFiles[0]!);
-  expect(reply.in_reply_to).toContain(inboxMsg.id);
+  expect(reply.origin).toContain(inboxMsg.id);
   expect(await list(inboxDir)).toHaveLength(0);
 });
 

--- a/packages/runner/src/agent-runner.ts
+++ b/packages/runner/src/agent-runner.ts
@@ -80,7 +80,8 @@ export class AgentRunner {
       { role: "user", content: message.body },
     ]);
 
-    await sendReply(this.home, this.agentName, response.text, filename);
+    const origin = message.origin ? `${message.origin}/${filename}` : filename;
+    await sendReply(this.home, this.agentName, response.text, origin);
     await acknowledge(this.inboxDir, filename);
     this.agent.status = "idle";
   }

--- a/packages/runtime/src/message.test.ts
+++ b/packages/runtime/src/message.test.ts
@@ -173,34 +173,75 @@ test("consume reads and moves message to .processed", async () => {
 
 // --- sendReply ---
 
-test("sendReply writes outbox message with in_reply_to", async () => {
+test("sendReply writes outbox message with origin", async () => {
   const outboxDir = join(root, AGENT, "outbox");
   mkdirSync(outboxDir, { recursive: true });
 
   const msg = await sendReply(root, AGENT, "reply body", "1234-abcd.msg");
 
-  expect(msg.in_reply_to).toBe("1234-abcd.msg");
+  expect(msg.origin).toBe("1234-abcd.msg");
   expect(msg.from).toBe(AGENT);
   expect(msg.body).toBe("reply body");
 
   const files = await list(outboxDir);
   expect(files).toHaveLength(1);
   const raw = await Bun.file(join(outboxDir, files[0] as string)).json();
-  expect(raw.in_reply_to).toBe("1234-abcd.msg");
+  expect(raw.origin).toBe("1234-abcd.msg");
 });
 
-// --- isMessage with in_reply_to ---
+test("sendReply writes outbox message with error flag", async () => {
+  const outboxDir = join(root, AGENT, "outbox");
+  mkdirSync(outboxDir, { recursive: true });
 
-test("isMessage accepts message with in_reply_to", () => {
+  const msg = await sendReply(root, AGENT, "timeout", "1234-abcd.msg", true);
+
+  expect(msg.origin).toBe("1234-abcd.msg");
+  expect(msg.error).toBe(true);
+
+  const files = await list(outboxDir);
+  const raw = await Bun.file(join(outboxDir, files[0] as string)).json();
+  expect(raw.error).toBe(true);
+});
+
+// --- isMessage with origin and error ---
+
+test("isMessage accepts message with origin", () => {
   expect(
-    isMessage({ v: 1, id: "abc", from: "sender", ts: 123, body: "hello", in_reply_to: "msg.msg" }),
+    isMessage({
+      v: 1,
+      id: "abc",
+      from: "sender",
+      ts: 123,
+      body: "hello",
+      origin: "1234-abcd.msg",
+    }),
   ).toBe(true);
 });
 
-test("isMessage rejects message with non-string in_reply_to", () => {
+test("isMessage accepts message with origin and error", () => {
   expect(
-    isMessage({ v: 1, id: "abc", from: "sender", ts: 123, body: "hello", in_reply_to: 42 }),
-  ).toBe(false);
+    isMessage({
+      v: 1,
+      id: "abc",
+      from: "sender",
+      ts: 123,
+      body: "fail",
+      origin: "1234-abcd.msg",
+      error: true,
+    }),
+  ).toBe(true);
+});
+
+test("isMessage rejects message with non-string origin", () => {
+  expect(isMessage({ v: 1, id: "abc", from: "sender", ts: 123, body: "hello", origin: 42 })).toBe(
+    false,
+  );
+});
+
+test("isMessage rejects message with non-boolean error", () => {
+  expect(isMessage({ v: 1, id: "abc", from: "sender", ts: 123, body: "hello", error: "yes" })).toBe(
+    false,
+  );
 });
 
 // --- fail ---
@@ -257,7 +298,7 @@ test("recover is a no-op when .in-progress is empty", async () => {
   await recover(inboxDir, outboxDir); // should not throw
 });
 
-test("recover acknowledges an in-progress message whose reply is already in outbox", async () => {
+test("recover acknowledges an in-progress message whose reply origin ends with its filename", async () => {
   const inboxDir = join(root, AGENT, "inbox");
   const outboxDir = join(root, AGENT, "outbox");
   mkdirSync(outboxDir, { recursive: true });

--- a/packages/runtime/src/message.ts
+++ b/packages/runtime/src/message.ts
@@ -20,8 +20,10 @@ export interface Message {
   from: string;
   ts: number;
   body: string;
-  /** Inbox filename that triggered this reply — used for idempotent restart recovery. */
-  in_reply_to?: string;
+  /** Slash-delimited path of message filenames tracing this pipeline run. */
+  origin?: string;
+  /** True when this message signals a processing failure. */
+  error?: boolean;
 }
 
 function generateId(): string {
@@ -40,12 +42,13 @@ export function send(root: string, agent: string, from: string, body: string): P
     .then(() => message);
 }
 
-/** Write an outbox message referencing the inbox filename that triggered it. */
+/** Write an outbox message referencing the pipeline origin path. */
 export function sendReply(
   root: string,
   agent: string,
   body: string,
-  inReplyTo: string,
+  origin: string,
+  error?: boolean,
 ): Promise<Message> {
   const id = generateId();
   const ts = Date.now();
@@ -56,7 +59,8 @@ export function sendReply(
     from: agent,
     ts,
     body,
-    in_reply_to: inReplyTo,
+    origin,
+    ...(error ? { error } : {}),
   };
 
   const path = join(root, agent, "outbox", `${ts}-${id}.msg`);
@@ -80,7 +84,8 @@ export function isMessage(obj: unknown): obj is Message {
     typeof obj.ts === "number" &&
     "body" in obj &&
     typeof obj.body === "string" &&
-    (!("in_reply_to" in obj) || typeof (obj as { in_reply_to: unknown }).in_reply_to === "string")
+    (!("origin" in obj) || typeof (obj as { origin: unknown }).origin === "string") &&
+    (!("error" in obj) || typeof (obj as { error: unknown }).error === "boolean")
   );
 }
 
@@ -157,7 +162,7 @@ export async function consume(dir: string, filename: string): Promise<Message> {
  * Recover in-progress messages left by a previous crash.
  *
  * For each file in `inboxDir/.in-progress/`:
- * - If `outboxDir` has a reply with matching `in_reply_to` → acknowledge (move to `.processed/`).
+ * - If `outboxDir` has a reply whose origin's last segment matches → acknowledge (move to `.processed/`).
  * - Otherwise → move back to `inboxDir` for reprocessing.
  */
 export async function recover(inboxDir: string, outboxDir: string): Promise<void> {
@@ -170,7 +175,10 @@ export async function recover(inboxDir: string, outboxDir: string): Promise<void
   const repliedTo = new Set<string>();
   for (const f of outboxFiles) {
     const msg = await read(outboxDir, f);
-    if (msg.in_reply_to) repliedTo.add(msg.in_reply_to);
+    if (msg.origin) {
+      const parent = msg.origin.split("/").pop();
+      if (parent) repliedTo.add(parent);
+    }
   }
 
   for (const filename of inProgressFiles) {


### PR DESCRIPTION
## Summary
- Replace `in_reply_to` with `origin` (slash-delimited path of message filenames tracing a pipeline run) and `error` (boolean failure signal) per ADR-009
- Update `sendReply()`, `isMessage()`, and `recover()` in runtime to use the new fields
- Update `AgentRunner.processMessage()` to build the origin path by appending the inbox filename to the incoming message's origin

## Test plan
- Verified `sendReply()` writes `origin` field to outbox messages (existing test updated)
- Verified `sendReply()` writes optional `error: true` flag (new test)
- Verified `isMessage()` accepts messages with `origin` and/or `error` fields (new tests)
- Verified `isMessage()` rejects non-string `origin` and non-boolean `error` (new tests)
- Verified `recover()` matches in-progress files by extracting the last segment of `origin` (existing test updated)
- Verified `AgentRunner` end-to-end: reply `origin` contains the inbox message ID (existing test updated)
- Verified crash recovery still works with origin-based matching (existing tests updated)
- All 101 tests pass, build succeeds, lint clean

Closes #72