### PR TITLE
✨ feat(cli): scaffold loom agent subcommand group and implement agent ps

### DIFF
--- a/packages/cli/src/commands/ps.test.ts
+++ b/packages/cli/src/commands/ps.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { AgentProcess } from "@losoft/loom-runtime";
+import { ps } from "./ps";
+
+let home: string;
+let logs: string[];
+const originalLog = console.log;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "cli-ps-"));
+  logs = [];
+  console.log = (...args: unknown[]) => logs.push(args.join(" "));
+});
+
+afterEach(() => {
+  console.log = originalLog;
+  rmSync(home, { recursive: true, force: true });
+});
+
+test("ps prints 'No agents found.' when no agents exist", async () => {
+  await ps([], home);
+  expect(logs).toEqual(["No agents found."]);
+});
+
+test("ps lists agents in a table", async () => {
+  const agentsDir = join(home, "agents");
+  const alice = new AgentProcess(agentsDir, "alice");
+  alice.status = "running";
+  alice.model = "ollama/llama3";
+  alice.pid = 1234;
+
+  const bob = new AgentProcess(agentsDir, "bob");
+  bob.status = "idle";
+  bob.model = "anthropic/claude-sonnet";
+
+  await ps([], home);
+
+  expect(logs.length).toBe(3); // header + 2 rows
+  expect(logs[0]).toContain("NAME");
+  expect(logs[0]).toContain("STATUS");
+  expect(logs[0]).toContain("MODEL");
+  expect(logs[0]).toContain("PID");
+
+  const output = logs.join("\n");
+  expect(output).toContain("alice");
+  expect(output).toContain("running");
+  expect(output).toContain("ollama/llama3");
+  expect(output).toContain("1234");
+  expect(output).toContain("bob");
+  expect(output).toContain("idle");
+});
+
+test("ps --json outputs JSON array", async () => {
+  const agentsDir = join(home, "agents");
+  const alice = new AgentProcess(agentsDir, "alice");
+  alice.status = "running";
+  alice.model = "ollama/llama3";
+  alice.pid = 42;
+
+  await ps(["--json"], home);
+
+  const parsed = JSON.parse(logs.join(""));
+  expect(parsed).toBeArray();
+  expect(parsed).toHaveLength(1);
+  expect(parsed[0].name).toBe("alice");
+  expect(parsed[0].status).toBe("running");
+  expect(parsed[0].model).toBe("ollama/llama3");
+  expect(parsed[0].pid).toBe(42);
+});
+
+test("ps --json outputs empty array when no agents exist", async () => {
+  await ps(["--json"], home);
+
+  const parsed = JSON.parse(logs.join(""));
+  expect(parsed).toEqual([]);
+});

--- a/packages/cli/src/commands/ps.ts
+++ b/packages/cli/src/commands/ps.ts
@@ -1,4 +1,39 @@
-/** List running agents. */
-export async function ps(_args: string[], _loomHome: string): Promise<void> {
-  console.log("loom ps — not yet implemented");
+import { join } from "node:path";
+import { type AgentEntry, ProcessTable } from "@losoft/loom-runtime";
+
+/** List all agents with name, status, model, and pid. */
+export async function ps(args: string[], loomHome: string): Promise<void> {
+  const table = new ProcessTable(join(loomHome, "agents"));
+  const entries = table.entries();
+
+  if (args.includes("--json")) {
+    console.log(JSON.stringify(entries, null, 2));
+    return;
+  }
+
+  if (entries.length === 0) {
+    console.log("No agents found.");
+    return;
+  }
+
+  printTable(entries);
+}
+
+function printTable(entries: AgentEntry[]): void {
+  const header = { name: "NAME", status: "STATUS", model: "MODEL", pid: "PID" };
+
+  const widths = {
+    name: Math.max(header.name.length, ...entries.map((e) => e.name.length)),
+    status: Math.max(header.status.length, ...entries.map((e) => e.status.length)),
+    model: Math.max(header.model.length, ...entries.map((e) => e.model.length)),
+    pid: Math.max(header.pid.length, ...entries.map((e) => String(e.pid ?? "—").length)),
+  };
+
+  const row = (name: string, status: string, model: string, pid: string) =>
+    `${name.padEnd(widths.name)}  ${status.padEnd(widths.status)}  ${model.padEnd(widths.model)}  ${pid}`;
+
+  console.log(row(header.name, header.status, header.model, header.pid));
+  for (const e of entries) {
+    console.log(row(e.name, e.status, e.model, String(e.pid ?? "—")));
+  }
 }

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env bun
 
+import { loomHome } from "@losoft/loom-runtime";
 import { down } from "./commands/down";
 import { logs } from "./commands/logs";
 import { ps } from "./commands/ps";
@@ -8,51 +9,81 @@ import { send } from "./commands/send";
 import { stop } from "./commands/stop";
 import { up } from "./commands/up";
 
-/** Resolve $LOOM_HOME, defaulting to ~/.loom. */
-function resolveLoomHome(): string {
-  return process.env.LOOM_HOME ?? `${process.env.HOME}/.loom`;
-}
+type CommandHandler = (args: string[], loomHome: string) => Promise<void>;
 
-const commands: Record<string, (args: string[], loomHome: string) => Promise<void>> = {
-  run,
+const agentCommands: Record<string, CommandHandler> = {
+  start: run,
   ps,
   stop,
-  up,
-  down,
   send,
   logs,
 };
 
-async function main(): Promise<void> {
-  const [command, ...args] = process.argv.slice(2);
+const topLevelCommands: Record<string, CommandHandler> = {
+  up,
+  down,
+};
 
-  if (!command || command === "--help" || command === "-h") {
+async function main(): Promise<void> {
+  const [first, ...rest] = process.argv.slice(2);
+
+  if (!first || first === "--help" || first === "-h") {
     printUsage();
     process.exit(0);
   }
 
-  const handler = commands[command];
+  const home = loomHome();
+
+  // loom agent <subcommand> [args...]
+  if (first === "agent") {
+    const [subcommand, ...args] = rest;
+    if (!subcommand || subcommand === "--help" || subcommand === "-h") {
+      printAgentUsage();
+      process.exit(0);
+    }
+
+    const handler = agentCommands[subcommand];
+    if (!handler) {
+      console.error(`Unknown agent command: ${subcommand}`);
+      printAgentUsage();
+      process.exit(1);
+    }
+
+    await handler(args, home);
+    return;
+  }
+
+  // Top-level commands (up, down)
+  const handler = topLevelCommands[first];
   if (!handler) {
-    console.error(`Unknown command: ${command}`);
+    console.error(`Unknown command: ${first}`);
     printUsage();
     process.exit(1);
   }
 
-  const loomHome = resolveLoomHome();
-  await handler(args, loomHome);
+  await handler(rest, home);
 }
 
 function printUsage(): void {
   console.log(`Usage: loom <command> [options]
 
 Commands:
-  run    Start a single agent
-  up     Start a weave of agents from loom.yml
-  ps     List running agents
-  stop   Stop a specific agent
-  down   Stop all agents from a weave
-  send   Send a message to an agent's inbox
-  logs   View agent logs`);
+  agent <subcommand>   Manage individual agents
+  up                   Start agents from loom.yml
+  down                 Stop all agents from loom.yml
+
+Run 'loom agent --help' for agent subcommands.`);
+}
+
+function printAgentUsage(): void {
+  console.log(`Usage: loom agent <command> [options]
+
+Commands:
+  start <name>   Start an agent
+  ps             List agents
+  stop <name>    Stop an agent
+  send <name>    Send a message to an agent
+  logs <name>    View agent logs`);
 }
 
 main().catch((err) => {


### PR DESCRIPTION
## Summary
- Restructure CLI for `loom agent <subcommand>` grouping per ADR-006 (replaces flat `loom ps`/`loom run` dispatch)
- Implement `loom agent ps` — reads `$LOOM_HOME/agents/*/status` via `ProcessTable`, prints formatted table with NAME, STATUS, MODEL, PID
- Support `--json` flag for machine-readable output
- Use `loomHome()` from runtime instead of inline `$HOME/.loom` resolution

## Test plan
- Verified `loom agent ps` prints "No agents found." when no agents exist
- Verified table output includes header and rows for multiple agents with correct fields
- Verified `--json` outputs valid JSON array with all agent entry fields
- Verified `--json` outputs empty array `[]` when no agents exist
- All 105 tests pass, build succeeds, lint clean

Closes #30