### PR TITLE
🐛 fix(ci): use pull_request_target for fork PR reviews

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,14 +1,11 @@
 name: Claude Code Review
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, ready_for_review, reopened]
     # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
+    paths:
+      - "packages/**/*.ts"
 
 jobs:
   claude-review:


### PR DESCRIPTION
## Summary
- Switch Claude Code review workflow from `pull_request` to `pull_request_target` so fork PRs have access to the `CLAUDE_CODE_OAUTH_TOKEN` secret
- Scope path filter to `packages/**/*.ts` to only trigger reviews on TypeScript source changes

## Test plan
- Open a PR from a fork that touches `packages/**/*.ts` and verify the Claude Code review workflow runs successfully and posts a review comment
- Confirm PRs from the main repo still trigger reviews as before
- Confirm PRs that only touch non-`.ts` files (e.g. docs, config) do not trigger the review