### PR TITLE
🐛 fix(ci): revert to pull_request trigger and skip fork PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,19 +1,12 @@
 name: Claude Code Review
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
-    # Optional: Only run on specific file changes
-    paths:
-      - "packages/**/*.ts"
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    if: github.event.pull_request.head.repo.full_name == github.repository
 
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary
- Revert `pull_request_target` back to `pull_request` — the OIDC token exchange fails with 401 under `pull_request_target`
- Skip fork PRs via `if:` guard since secrets aren't available for forks anyway
- Remove `paths` filter so reviews run on all file changes

## Test plan
- Verify the workflow triggers on the next non-fork PR with any file changes
- Confirm OIDC token exchange succeeds (no more 401 errors)
- Confirm the job is skipped for fork PRs