### PR TITLE
✨ feat(runner): add Ollama, OpenAI, and OpenRouter provider adapters

### DIFF
--- a/docs/adrs/ADR-008-ollama-model-availability.md
+++ b/docs/adrs/ADR-008-ollama-model-availability.md
@@ -16,9 +16,10 @@ no clear indication of what went wrong or how to fix it.
 
 ## Decision
 
-The Ollama provider adapter checks the response status before attempting to parse the stream.
-If Ollama returns a 404 with a model-not-found body, the runner throws a structured
-`ModelNotFoundError` immediately — no retry, no auto-pull.
+The Ollama provider adapter extends `OpenAiCompatibleProvider` and calls Ollama's
+OpenAI-compatible `/v1/chat/completions` endpoint (rather than the native `/api/chat`).
+It checks the response status before parsing. If Ollama returns a 404 with a model-not-found
+body, the runner throws a structured `ModelNotFoundError` immediately — no retry, no auto-pull.
 
 The error message is actionable:
 
@@ -71,3 +72,4 @@ to produce a better message.
 | Date | Change |
 |---|---|
 | 2026-04-01 | Initial decision. |
+| 2026-04-06 | Ollama adapter now uses OpenAI-compatible `/v1/chat/completions` instead of native `/api/chat`, via shared `OpenAiCompatibleProvider` base class. Core behaviour unchanged. |

--- a/docs/adrs/ADR-013-model-routing.md
+++ b/docs/adrs/ADR-013-model-routing.md
@@ -81,15 +81,15 @@ function resolveProvider(model: string): { provider: Provider; modelName: string
 All providers are implemented as plain HTTP calls using `fetch()`. No SDKs, no
 external runtime dependencies. This is a hard constraint for `@losoft/loom-runtime`.
 
-Ollama exposes two APIs — a native `/api/chat` and an OpenAI-compatible `/v1/chat/completions`.
-loom uses the *native* `/api/chat` endpoint to avoid coupling the implementation to OpenAI's
-request/response format. The OpenAI-compatible mode remains available as an escape hatch via
-`OPENAI_BASE_URL=http://localhost:11434/v1`.
+Ollama, OpenAI, and OpenRouter all use the OpenAI `/v1/chat/completions` wire format.
+A shared `OpenAiCompatibleProvider` base class handles message conversion, response parsing,
+and error handling. The three built-in subclasses (`OllamaProvider`, `OpenAiProvider`,
+`OpenRouterProvider`) supply provider-specific configuration (base URL, auth headers, error
+hints). The base class is also directly instantiable for custom OpenAI-compatible endpoints
+(e.g. LM Studio, Together, Fireworks) via `loom.config.ts`.
 
 Anthropic does not support the OpenAI format. Its provider adapter calls the Anthropic REST API
-directly (`/v1/messages`), normalising the response into `ChatChunk` internally.
-
-OpenAI and OpenRouter both use the same request format and are called directly via `fetch()`.
+directly (`/v1/messages`), normalising the response into `ChatResponse` internally.
 
 ### Provider interface
 
@@ -247,3 +247,4 @@ common case of one provider per agent. Rejected in favour of prefix-in-model-str
 | 2026-03-25 | Initial draft. |
 | 2026-04-01 | **Provider implementation details.** All providers use plain `fetch()` — no SDKs. Ollama native `/api/chat`, Anthropic `/v1/messages`, OpenAI-compatible escape hatch. Added Ollama multi-model thrashing guidance and deployment pattern table. |
 | 2026-04-03 | **Defined missing types.** Added `ContentPart` (text, image, tool_use, tool_result), `ToolDefinition` (name, description, input_schema), and `tool_use_id` on `ChatMessage`. Noted that providers normalise native formats into these common types. |
+| 2026-04-06 | **Shared OpenAI-compatible base.** Ollama, OpenAI, and OpenRouter now share `OpenAiCompatibleProvider` calling `/v1/chat/completions`. Ollama no longer uses native `/api/chat`. Anthropic remains separate. |

--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -10,4 +10,16 @@ export {
   resolveProvider,
   type ToolCall,
 } from "./provider";
-export { AnthropicProvider, type AnthropicProviderOptions, EchoProvider } from "./providers";
+export {
+  AnthropicProvider,
+  type AnthropicProviderOptions,
+  EchoProvider,
+  OllamaProvider,
+  type OllamaProviderOptions,
+  type OpenAiCompatibleConfig,
+  OpenAiCompatibleProvider,
+  OpenAiProvider,
+  type OpenAiProviderOptions,
+  OpenRouterProvider,
+  type OpenRouterProviderOptions,
+} from "./providers";

--- a/packages/runner/src/provider.ts
+++ b/packages/runner/src/provider.ts
@@ -1,5 +1,8 @@
 import { AnthropicProvider } from "./providers/anthropic";
 import { EchoProvider } from "./providers/echo";
+import { OllamaProvider } from "./providers/ollama";
+import { OpenAiProvider } from "./providers/openai";
+import { OpenRouterProvider } from "./providers/openrouter";
 
 /** A single message in a conversation turn. */
 export interface ChatMessage {
@@ -48,6 +51,9 @@ export function createDefaultRegistry(): ProviderRegistry {
   const registry = new ProviderRegistry();
   registry.register("anthropic", new AnthropicProvider());
   registry.register("echo", new EchoProvider());
+  registry.register("ollama", new OllamaProvider());
+  registry.register("openai", new OpenAiProvider());
+  registry.register("openrouter", new OpenRouterProvider());
   return registry;
 }
 

--- a/packages/runner/src/providers/index.ts
+++ b/packages/runner/src/providers/index.ts
@@ -1,2 +1,6 @@
 export { AnthropicProvider, type AnthropicProviderOptions } from "./anthropic";
 export { EchoProvider } from "./echo";
+export { OllamaProvider, type OllamaProviderOptions } from "./ollama";
+export { OpenAiProvider, type OpenAiProviderOptions } from "./openai";
+export { type OpenAiCompatibleConfig, OpenAiCompatibleProvider } from "./openai-compatible";
+export { OpenRouterProvider, type OpenRouterProviderOptions } from "./openrouter";

--- a/packages/runner/src/providers/ollama.test.ts
+++ b/packages/runner/src/providers/ollama.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { ModelNotFoundError } from "../errors";
+import { OllamaProvider } from "./ollama";
+
+const originalFetch = globalThis.fetch;
+
+function mockFetchCapture(
+  status: number,
+  body: unknown,
+): { getRequest: () => { url: string; init: RequestInit } } {
+  let captured: { url: string; init: RequestInit };
+  globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+    captured = { url, init: init! };
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { "content-type": "application/json" },
+    });
+  }) as unknown as typeof fetch;
+  return { getRequest: () => captured };
+}
+
+const OK_RESPONSE = { choices: [{ message: { role: "assistant", content: "Hi" } }] };
+
+beforeEach(() => {
+  delete process.env.OLLAMA_BASE_URL;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+test("default base URL is http://localhost:11434", async () => {
+  const cap = mockFetchCapture(200, OK_RESPONSE);
+  const provider = new OllamaProvider();
+  await provider.chat("qwen2.5:3b", "", [{ role: "user", content: "Hi" }]);
+  expect(cap.getRequest().url).toBe("http://localhost:11434/v1/chat/completions");
+});
+
+test("OLLAMA_BASE_URL env overrides default", async () => {
+  process.env.OLLAMA_BASE_URL = "http://remote:11434";
+  const cap = mockFetchCapture(200, OK_RESPONSE);
+  const provider = new OllamaProvider();
+  await provider.chat("qwen2.5:3b", "", [{ role: "user", content: "Hi" }]);
+  expect(cap.getRequest().url).toBe("http://remote:11434/v1/chat/completions");
+});
+
+test("constructor baseUrl overrides env", async () => {
+  process.env.OLLAMA_BASE_URL = "http://env:11434";
+  const cap = mockFetchCapture(200, OK_RESPONSE);
+  const provider = new OllamaProvider({ baseUrl: "http://constructor:11434" });
+  await provider.chat("qwen2.5:3b", "", [{ role: "user", content: "Hi" }]);
+  expect(cap.getRequest().url).toBe("http://constructor:11434/v1/chat/completions");
+});
+
+test("no Authorization header is sent", async () => {
+  const cap = mockFetchCapture(200, OK_RESPONSE);
+  const provider = new OllamaProvider();
+  await provider.chat("qwen2.5:3b", "", [{ role: "user", content: "Hi" }]);
+  const headers = cap.getRequest().init.headers as Record<string, string>;
+  expect(headers.authorization).toBeUndefined();
+});
+
+test("404 includes ollama pull hint", async () => {
+  mockFetchCapture(404, { error: { message: "model not found" } });
+  const provider = new OllamaProvider();
+  await expect(provider.chat("qwen2.5:3b", "", [{ role: "user", content: "Hi" }])).rejects.toThrow(
+    "Run: ollama pull qwen2.5:3b",
+  );
+});
+
+test("404 throws ModelNotFoundError", async () => {
+  mockFetchCapture(404, { error: { message: "model not found" } });
+  const provider = new OllamaProvider();
+  await expect(provider.chat("qwen2.5:3b", "", [{ role: "user", content: "Hi" }])).rejects.toThrow(
+    ModelNotFoundError,
+  );
+});
+
+test("trailing slash on baseUrl is stripped", async () => {
+  const cap = mockFetchCapture(200, OK_RESPONSE);
+  const provider = new OllamaProvider({ baseUrl: "http://localhost:11434/" });
+  await provider.chat("qwen2.5:3b", "", [{ role: "user", content: "Hi" }]);
+  expect(cap.getRequest().url).toBe("http://localhost:11434/v1/chat/completions");
+});

--- a/packages/runner/src/providers/ollama.ts
+++ b/packages/runner/src/providers/ollama.ts
@@ -1,0 +1,17 @@
+import { OpenAiCompatibleProvider } from "./openai-compatible";
+
+export interface OllamaProviderOptions {
+  baseUrl?: string;
+}
+
+/** Ollama provider using the OpenAI-compatible /v1/chat/completions endpoint. */
+export class OllamaProvider extends OpenAiCompatibleProvider {
+  constructor(options?: OllamaProviderOptions) {
+    super({
+      providerName: "ollama",
+      baseUrl: options?.baseUrl ?? process.env.OLLAMA_BASE_URL ?? "http://localhost:11434",
+      headers: {},
+      modelNotFoundHint: (model) => `Run: ollama pull ${model}`,
+    });
+  }
+}

--- a/packages/runner/src/providers/openai-compatible.test.ts
+++ b/packages/runner/src/providers/openai-compatible.test.ts
@@ -1,0 +1,222 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { ModelNotFoundError, ProviderAuthError } from "../errors";
+import { OpenAiCompatibleProvider } from "./openai-compatible";
+
+const originalFetch = globalThis.fetch;
+
+function mockFetch(status: number, body: unknown): void {
+  globalThis.fetch = (async () =>
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { "content-type": "application/json" },
+    })) as unknown as typeof fetch;
+}
+
+/** Mock fetch that captures the request for assertions. */
+function mockFetchCapture(
+  status: number,
+  body: unknown,
+): { getRequest: () => { url: string; init: RequestInit; body: Record<string, unknown> } } {
+  let captured: { url: string; init: RequestInit; body: Record<string, unknown> };
+  globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+    captured = { url, init: init!, body: JSON.parse(init?.body as string) };
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { "content-type": "application/json" },
+    });
+  }) as unknown as typeof fetch;
+  return {
+    getRequest: () => captured,
+  };
+}
+
+const OK_RESPONSE = {
+  choices: [
+    {
+      message: {
+        role: "assistant",
+        content: "Hello",
+      },
+    },
+  ],
+};
+
+function createProvider(overrides?: Partial<import("./openai-compatible").OpenAiCompatibleConfig>) {
+  return new OpenAiCompatibleProvider({
+    providerName: "test",
+    baseUrl: "https://api.example.com",
+    headers: {},
+    ...overrides,
+  });
+}
+
+beforeEach(() => {});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+test("successful text response", async () => {
+  mockFetch(200, OK_RESPONSE);
+  const provider = createProvider();
+  const result = await provider.chat("test-model", "Be helpful", [{ role: "user", content: "Hi" }]);
+  expect(result.text).toBe("Hello");
+  expect(result.toolCalls).toBeUndefined();
+});
+
+test("null content returns empty string", async () => {
+  mockFetch(200, { choices: [{ message: { role: "assistant", content: null } }] });
+  const provider = createProvider();
+  const result = await provider.chat("test-model", "", [{ role: "user", content: "Hi" }]);
+  expect(result.text).toBe("");
+});
+
+test("tool call response maps to toolCalls", async () => {
+  mockFetch(200, {
+    choices: [
+      {
+        message: {
+          role: "assistant",
+          content: null,
+          tool_calls: [
+            {
+              id: "call_1",
+              type: "function",
+              function: { name: "search", arguments: '{"query":"test"}' },
+            },
+          ],
+        },
+      },
+    ],
+  });
+  const provider = createProvider();
+  const result = await provider.chat("test-model", "", [
+    { role: "user", content: "Search for test" },
+  ]);
+  expect(result.text).toBe("");
+  expect(result.toolCalls).toEqual([{ id: "call_1", name: "search", input: { query: "test" } }]);
+});
+
+test("mixed text and tool_calls", async () => {
+  mockFetch(200, {
+    choices: [
+      {
+        message: {
+          role: "assistant",
+          content: "Let me search for that.",
+          tool_calls: [
+            {
+              id: "call_1",
+              type: "function",
+              function: { name: "search", arguments: '{"q":"loom"}' },
+            },
+          ],
+        },
+      },
+    ],
+  });
+  const provider = createProvider();
+  const result = await provider.chat("test-model", "", [{ role: "user", content: "Find loom" }]);
+  expect(result.text).toBe("Let me search for that.");
+  expect(result.toolCalls).toEqual([{ id: "call_1", name: "search", input: { q: "loom" } }]);
+});
+
+test("401 throws ProviderAuthError", async () => {
+  mockFetch(401, { error: { message: "Invalid key" } });
+  const provider = createProvider();
+  await expect(provider.chat("test-model", "", [{ role: "user", content: "Hi" }])).rejects.toThrow(
+    ProviderAuthError,
+  );
+});
+
+test("404 throws ModelNotFoundError", async () => {
+  mockFetch(404, { error: { message: "Model not found" } });
+  const provider = createProvider();
+  await expect(
+    provider.chat("nonexistent-model", "", [{ role: "user", content: "Hi" }]),
+  ).rejects.toThrow(ModelNotFoundError);
+});
+
+test("404 includes hint when modelNotFoundHint is configured", async () => {
+  mockFetch(404, { error: { message: "Model not found" } });
+  const provider = createProvider({
+    modelNotFoundHint: (model) => `Run: ollama pull ${model}`,
+  });
+  await expect(provider.chat("qwen2.5:3b", "", [{ role: "user", content: "Hi" }])).rejects.toThrow(
+    "Run: ollama pull qwen2.5:3b",
+  );
+});
+
+test("500 throws generic Error with status", async () => {
+  mockFetch(500, { error: { message: "Internal error" } });
+  const provider = createProvider();
+  await expect(provider.chat("test-model", "", [{ role: "user", content: "Hi" }])).rejects.toThrow(
+    /test API error \(500\)/,
+  );
+});
+
+test("system prompt is included as first message when non-empty", async () => {
+  const cap = mockFetchCapture(200, OK_RESPONSE);
+  const provider = createProvider();
+  await provider.chat("test-model", "Be concise", [{ role: "user", content: "Hi" }]);
+  const messages = cap.getRequest().body.messages as Array<Record<string, unknown>>;
+  expect(messages[0]).toEqual({ role: "system", content: "Be concise" });
+  expect(messages[1]).toEqual({ role: "user", content: "Hi" });
+});
+
+test("system prompt is omitted when empty", async () => {
+  const cap = mockFetchCapture(200, OK_RESPONSE);
+  const provider = createProvider();
+  await provider.chat("test-model", "", [{ role: "user", content: "Hi" }]);
+  const messages = cap.getRequest().body.messages as Array<Record<string, unknown>>;
+  expect(messages[0]).toEqual({ role: "user", content: "Hi" });
+});
+
+test("tool message is mapped to OpenAI tool format", async () => {
+  const cap = mockFetchCapture(200, OK_RESPONSE);
+  const provider = createProvider();
+  await provider.chat("test-model", "", [
+    { role: "user", content: "Search for test" },
+    { role: "assistant", content: "" },
+    { role: "tool", content: '{"result": "found"}', toolCallId: "call_1" },
+  ]);
+  const messages = cap.getRequest().body.messages as Array<Record<string, unknown>>;
+  expect(messages[2]).toEqual({
+    role: "tool",
+    tool_call_id: "call_1",
+    content: '{"result": "found"}',
+  });
+});
+
+test("custom headers are passed through", async () => {
+  const cap = mockFetchCapture(200, OK_RESPONSE);
+  const provider = createProvider({
+    headers: { authorization: "Bearer sk-test", "x-custom": "value" },
+  });
+  await provider.chat("test-model", "", [{ role: "user", content: "Hi" }]);
+  const headers = cap.getRequest().init.headers as Record<string, string>;
+  expect(headers.authorization).toBe("Bearer sk-test");
+  expect(headers["x-custom"]).toBe("value");
+});
+
+test("trailing slash on baseUrl is stripped", async () => {
+  const cap = mockFetchCapture(200, OK_RESPONSE);
+  const provider = createProvider({ baseUrl: "https://api.example.com/" });
+  await provider.chat("test-model", "", [{ role: "user", content: "Hi" }]);
+  expect(cap.getRequest().url).toBe("https://api.example.com/v1/chat/completions");
+});
+
+test("model is sent in request body", async () => {
+  const cap = mockFetchCapture(200, OK_RESPONSE);
+  const provider = createProvider();
+  await provider.chat("gpt-4o", "", [{ role: "user", content: "Hi" }]);
+  expect(cap.getRequest().body.model).toBe("gpt-4o");
+});
+
+test("fetch URL uses baseUrl with /v1/chat/completions", async () => {
+  const cap = mockFetchCapture(200, OK_RESPONSE);
+  const provider = createProvider({ baseUrl: "https://custom.example.com" });
+  await provider.chat("test-model", "", [{ role: "user", content: "Hi" }]);
+  expect(cap.getRequest().url).toBe("https://custom.example.com/v1/chat/completions");
+});

--- a/packages/runner/src/providers/openai-compatible.ts
+++ b/packages/runner/src/providers/openai-compatible.ts
@@ -1,0 +1,108 @@
+import { ModelNotFoundError, ProviderAuthError } from "../errors";
+import type { ChatMessage, ChatResponse, Provider, ToolCall } from "../provider";
+
+/** Configuration for an OpenAI-compatible provider. */
+export interface OpenAiCompatibleConfig {
+  providerName: string;
+  baseUrl: string;
+  headers: Record<string, string>;
+  modelNotFoundHint?: (model: string) => string;
+}
+
+interface OpenAiChoice {
+  message: {
+    role: string;
+    content: string | null;
+    tool_calls?: OpenAiToolCall[];
+  };
+}
+
+interface OpenAiToolCall {
+  id: string;
+  type: "function";
+  function: { name: string; arguments: string };
+}
+
+interface OpenAiErrorResponse {
+  error?: { message?: string };
+}
+
+/** Convert loom ChatMessages to OpenAI message format. */
+function toOpenAiMessages(system: string, messages: ChatMessage[]): Record<string, unknown>[] {
+  const result: Record<string, unknown>[] = [];
+  if (system) {
+    result.push({ role: "system", content: system });
+  }
+  for (const msg of messages) {
+    if (msg.role === "tool") {
+      result.push({ role: "tool", tool_call_id: msg.toolCallId ?? "", content: msg.content });
+    } else {
+      result.push({ role: msg.role, content: msg.content });
+    }
+  }
+  return result;
+}
+
+/** Extract tool calls from an OpenAI choice. */
+function extractToolCalls(choice: OpenAiChoice): ToolCall[] | undefined {
+  const calls = choice.message.tool_calls;
+  if (!calls || calls.length === 0) return undefined;
+  return calls.map((tc) => ({
+    id: tc.id,
+    name: tc.function.name,
+    input: JSON.parse(tc.function.arguments) as Record<string, unknown>,
+  }));
+}
+
+/** Provider for any OpenAI-compatible chat completions API. */
+export class OpenAiCompatibleProvider implements Provider {
+  private readonly config: OpenAiCompatibleConfig;
+
+  /** Creates a provider with the given configuration. */
+  constructor(config: OpenAiCompatibleConfig) {
+    this.config = { ...config, baseUrl: config.baseUrl.replace(/\/$/, "") };
+  }
+
+  /** Send a chat turn to an OpenAI-compatible /v1/chat/completions endpoint. */
+  async chat(model: string, system: string, messages: ChatMessage[]): Promise<ChatResponse> {
+    const response = await fetch(`${this.config.baseUrl}/v1/chat/completions`, {
+      method: "POST",
+      headers: { "content-type": "application/json", ...this.config.headers },
+      body: JSON.stringify({ model, messages: toOpenAiMessages(system, messages) }),
+    });
+
+    if (!response.ok) {
+      let errorMessage = `${this.config.providerName} API error (${response.status})`;
+      try {
+        const err = (await response.json()) as OpenAiErrorResponse;
+        errorMessage = err.error?.message ?? errorMessage;
+      } catch {
+        /* use default message */
+      }
+
+      if (response.status === 401) {
+        throw new ProviderAuthError(this.config.providerName);
+      }
+      if (response.status === 404) {
+        throw new ModelNotFoundError(
+          this.config.providerName,
+          model,
+          this.config.modelNotFoundHint?.(model),
+        );
+      }
+      throw new Error(
+        `${this.config.providerName} API error (${response.status}): ${errorMessage}`,
+      );
+    }
+
+    const data = (await response.json()) as { choices: OpenAiChoice[] };
+    const choice = data.choices[0];
+    if (!choice) {
+      throw new Error(`${this.config.providerName}: response contained no choices`);
+    }
+    return {
+      text: choice.message.content ?? "",
+      toolCalls: extractToolCalls(choice),
+    };
+  }
+}

--- a/packages/runner/src/providers/openai.test.ts
+++ b/packages/runner/src/providers/openai.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { OpenAiProvider } from "./openai";
+
+const originalFetch = globalThis.fetch;
+
+function mockFetchCapture(
+  status: number,
+  body: unknown,
+): { getRequest: () => { url: string; init: RequestInit } } {
+  let captured: { url: string; init: RequestInit };
+  globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+    captured = { url, init: init! };
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { "content-type": "application/json" },
+    });
+  }) as unknown as typeof fetch;
+  return { getRequest: () => captured };
+}
+
+const OK_RESPONSE = { choices: [{ message: { role: "assistant", content: "Hi" } }] };
+
+beforeEach(() => {
+  delete process.env.OPENAI_API_KEY;
+  delete process.env.OPENAI_BASE_URL;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+test("default base URL is https://api.openai.com", async () => {
+  const cap = mockFetchCapture(200, OK_RESPONSE);
+  const provider = new OpenAiProvider({ apiKey: "sk-test" });
+  await provider.chat("gpt-4o", "", [{ role: "user", content: "Hi" }]);
+  expect(cap.getRequest().url).toBe("https://api.openai.com/v1/chat/completions");
+});
+
+test("OPENAI_BASE_URL env overrides default", async () => {
+  process.env.OPENAI_BASE_URL = "https://custom.openai.com";
+  const cap = mockFetchCapture(200, OK_RESPONSE);
+  const provider = new OpenAiProvider({ apiKey: "sk-test" });
+  await provider.chat("gpt-4o", "", [{ role: "user", content: "Hi" }]);
+  expect(cap.getRequest().url).toBe("https://custom.openai.com/v1/chat/completions");
+});
+
+test("constructor baseUrl overrides env", async () => {
+  process.env.OPENAI_BASE_URL = "https://env.openai.com";
+  const cap = mockFetchCapture(200, OK_RESPONSE);
+  const provider = new OpenAiProvider({
+    apiKey: "sk-test",
+    baseUrl: "https://constructor.openai.com",
+  });
+  await provider.chat("gpt-4o", "", [{ role: "user", content: "Hi" }]);
+  expect(cap.getRequest().url).toBe("https://constructor.openai.com/v1/chat/completions");
+});
+
+test("apiKey falls back to OPENAI_API_KEY env var", async () => {
+  process.env.OPENAI_API_KEY = "env-key";
+  const cap = mockFetchCapture(200, OK_RESPONSE);
+  const provider = new OpenAiProvider();
+  await provider.chat("gpt-4o", "", [{ role: "user", content: "Hi" }]);
+  const headers = cap.getRequest().init.headers as Record<string, string>;
+  expect(headers.authorization).toBe("Bearer env-key");
+});
+
+test("constructor apiKey overrides env", async () => {
+  process.env.OPENAI_API_KEY = "env-key";
+  const cap = mockFetchCapture(200, OK_RESPONSE);
+  const provider = new OpenAiProvider({ apiKey: "constructor-key" });
+  await provider.chat("gpt-4o", "", [{ role: "user", content: "Hi" }]);
+  const headers = cap.getRequest().init.headers as Record<string, string>;
+  expect(headers.authorization).toBe("Bearer constructor-key");
+});
+
+test("Authorization Bearer header is sent", async () => {
+  const cap = mockFetchCapture(200, OK_RESPONSE);
+  const provider = new OpenAiProvider({ apiKey: "sk-test" });
+  await provider.chat("gpt-4o", "", [{ role: "user", content: "Hi" }]);
+  const headers = cap.getRequest().init.headers as Record<string, string>;
+  expect(headers.authorization).toBe("Bearer sk-test");
+});
+
+test("trailing slash on baseUrl is stripped", async () => {
+  const cap = mockFetchCapture(200, OK_RESPONSE);
+  const provider = new OpenAiProvider({ apiKey: "sk-test", baseUrl: "https://api.openai.com/" });
+  await provider.chat("gpt-4o", "", [{ role: "user", content: "Hi" }]);
+  expect(cap.getRequest().url).toBe("https://api.openai.com/v1/chat/completions");
+});

--- a/packages/runner/src/providers/openai.ts
+++ b/packages/runner/src/providers/openai.ts
@@ -1,0 +1,18 @@
+import { OpenAiCompatibleProvider } from "./openai-compatible";
+
+export interface OpenAiProviderOptions {
+  apiKey?: string;
+  baseUrl?: string;
+}
+
+/** OpenAI provider using the /v1/chat/completions endpoint. */
+export class OpenAiProvider extends OpenAiCompatibleProvider {
+  constructor(options?: OpenAiProviderOptions) {
+    const apiKey = options?.apiKey ?? process.env.OPENAI_API_KEY ?? "";
+    super({
+      providerName: "openai",
+      baseUrl: options?.baseUrl ?? process.env.OPENAI_BASE_URL ?? "https://api.openai.com",
+      headers: { authorization: `Bearer ${apiKey}` },
+    });
+  }
+}

--- a/packages/runner/src/providers/openrouter.test.ts
+++ b/packages/runner/src/providers/openrouter.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { OpenRouterProvider } from "./openrouter";
+
+const originalFetch = globalThis.fetch;
+
+function mockFetchCapture(
+  status: number,
+  body: unknown,
+): { getRequest: () => { url: string; init: RequestInit } } {
+  let captured: { url: string; init: RequestInit };
+  globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+    captured = { url, init: init! };
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { "content-type": "application/json" },
+    });
+  }) as unknown as typeof fetch;
+  return { getRequest: () => captured };
+}
+
+const OK_RESPONSE = { choices: [{ message: { role: "assistant", content: "Hi" } }] };
+
+beforeEach(() => {
+  delete process.env.OPENROUTER_API_KEY;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+test("base URL is https://openrouter.ai/api", async () => {
+  const cap = mockFetchCapture(200, OK_RESPONSE);
+  const provider = new OpenRouterProvider({ apiKey: "sk-or-test" });
+  await provider.chat("anthropic/claude-sonnet-4-6", "", [{ role: "user", content: "Hi" }]);
+  expect(cap.getRequest().url).toBe("https://openrouter.ai/api/v1/chat/completions");
+});
+
+test("apiKey falls back to OPENROUTER_API_KEY env var", async () => {
+  process.env.OPENROUTER_API_KEY = "env-key";
+  const cap = mockFetchCapture(200, OK_RESPONSE);
+  const provider = new OpenRouterProvider();
+  await provider.chat("anthropic/claude-sonnet-4-6", "", [{ role: "user", content: "Hi" }]);
+  const headers = cap.getRequest().init.headers as Record<string, string>;
+  expect(headers.authorization).toBe("Bearer env-key");
+});
+
+test("constructor apiKey overrides env", async () => {
+  process.env.OPENROUTER_API_KEY = "env-key";
+  const cap = mockFetchCapture(200, OK_RESPONSE);
+  const provider = new OpenRouterProvider({ apiKey: "constructor-key" });
+  await provider.chat("anthropic/claude-sonnet-4-6", "", [{ role: "user", content: "Hi" }]);
+  const headers = cap.getRequest().init.headers as Record<string, string>;
+  expect(headers.authorization).toBe("Bearer constructor-key");
+});
+
+test("Authorization Bearer header is sent", async () => {
+  const cap = mockFetchCapture(200, OK_RESPONSE);
+  const provider = new OpenRouterProvider({ apiKey: "sk-or-test" });
+  await provider.chat("anthropic/claude-sonnet-4-6", "", [{ role: "user", content: "Hi" }]);
+  const headers = cap.getRequest().init.headers as Record<string, string>;
+  expect(headers.authorization).toBe("Bearer sk-or-test");
+});
+
+test("HTTP-Referer header is sent", async () => {
+  const cap = mockFetchCapture(200, OK_RESPONSE);
+  const provider = new OpenRouterProvider({ apiKey: "sk-or-test" });
+  await provider.chat("anthropic/claude-sonnet-4-6", "", [{ role: "user", content: "Hi" }]);
+  const headers = cap.getRequest().init.headers as Record<string, string>;
+  expect(headers["http-referer"]).toBe("https://github.com/losoft-org/loom");
+});
+
+test("X-Title header is sent", async () => {
+  const cap = mockFetchCapture(200, OK_RESPONSE);
+  const provider = new OpenRouterProvider({ apiKey: "sk-or-test" });
+  await provider.chat("anthropic/claude-sonnet-4-6", "", [{ role: "user", content: "Hi" }]);
+  const headers = cap.getRequest().init.headers as Record<string, string>;
+  expect(headers["x-title"]).toBe("loom");
+});

--- a/packages/runner/src/providers/openrouter.ts
+++ b/packages/runner/src/providers/openrouter.ts
@@ -1,0 +1,21 @@
+import { OpenAiCompatibleProvider } from "./openai-compatible";
+
+export interface OpenRouterProviderOptions {
+  apiKey?: string;
+}
+
+/** OpenRouter provider using the OpenAI-compatible /v1/chat/completions endpoint. */
+export class OpenRouterProvider extends OpenAiCompatibleProvider {
+  constructor(options?: OpenRouterProviderOptions) {
+    const apiKey = options?.apiKey ?? process.env.OPENROUTER_API_KEY ?? "";
+    super({
+      providerName: "openrouter",
+      baseUrl: "https://openrouter.ai/api",
+      headers: {
+        authorization: `Bearer ${apiKey}`,
+        "http-referer": "https://github.com/losoft-org/loom",
+        "x-title": "loom",
+      },
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- Add `OpenAiCompatibleProvider` shared base class for the `/v1/chat/completions` wire format
- Implement `OllamaProvider` (no auth, `OLLAMA_BASE_URL`, "Run: ollama pull" hint on 404)
- Implement `OpenAiProvider` (Bearer auth via `OPENAI_API_KEY`, configurable `OPENAI_BASE_URL`)
- Implement `OpenRouterProvider` (Bearer auth via `OPENROUTER_API_KEY`, `HTTP-Referer` + `X-Title` headers)
- Register all three in `createDefaultRegistry()` and export from package barrel
- Update ADR-008 and ADR-013 to reflect shared OpenAI-compatible approach

Closes #67, closes #82, closes #83

## Test plan
- 15 base class tests cover response parsing (text, tool calls, mixed), error handling (401/404/500), system prompt, tool messages, and request construction
- 7 Ollama tests verify default/env/constructor base URL, no auth header, 404 hint with model name
- 7 OpenAI tests verify default/env/constructor base URL, Bearer auth header, env fallback and override
- 6 OpenRouter tests verify fixed base URL, Bearer auth, HTTP-Referer and X-Title headers
- `bun test` — 189 tests pass (35 new)
- `bun run build` — all packages build for both Bun and Node targets
- `bun run check` — biome clean