### PR TITLE
chore: remove gitmoji from commit conventions, use plain conventional commits

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -115,7 +115,7 @@ afterEach(() => {
 
 ### Commits and PRs
 
-Conventional Commits with gitmoji: `✨ feat:`, `🐛 fix:`, `📝 docs:`, `♻️ refactor:`, `🧪 test:`, `🚀 chore:`, `⚡ perf:`. PRs are squash-merged, so the PR title becomes the commit message.
+Conventional Commits: `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`, `perf:`. PRs are squash-merged, so the PR title becomes the commit message.
 
 ### ADRs
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,6 @@ Each package builds for both Bun and Node.js targets (`dist/bun/` and `dist/node
 
 - TypeScript strict mode. Biome for linting/formatting (spaces, double quotes, semicolons, trailing commas, 100-char line width).
 - Tests live alongside source as `*.test.ts` files. Tests should verify filesystem state, not just return values.
-- Commits use Conventional Commits with gitmoji (e.g. `✨ feat:`, `🐛 fix:`, `📝 docs:`, `♻️ refactor:`, `🧪 test:`).
+- Commits use Conventional Commits (e.g. `feat:`, `fix:`, `docs:`, `refactor:`, `test:`).
 - Every public function needs a one-line JSDoc comment.
 - Core vs plugin boundary: if it requires an external service or adds a dependency to core, it's a plugin (separate `@losoft/loom-*` package).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,25 +111,25 @@ All three must pass before merging. PRs also receive automated code review.
 
 ## Commits
 
-We use [Conventional Commits](https://www.conventionalcommits.org/) with [gitmoji](https://gitmoji.dev/):
+We use [Conventional Commits](https://www.conventionalcommits.org/):
 
 ```
-✨ feat: add inbox watcher polling interval config
-🐛 fix: supervisor restart backoff not resetting after stable run
-📝 docs: add ADR-012 for message deduplication
-♻️ refactor: extract frame parsing into separate module
-🧪 test: add process-table register/deregister cases
+feat: add inbox watcher polling interval config
+fix: supervisor restart backoff not resetting after stable run
+docs: add ADR-012 for message deduplication
+refactor: extract frame parsing into separate module
+test: add process-table register/deregister cases
 ```
 
 Common prefixes: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`, `perf`
 
 ## Pull requests
 
-PRs are squash-merged into `main`, so the **PR title becomes the commit message**. Use the same gitmoji + Conventional Commits format for PR titles:
+PRs are squash-merged into `main`, so the **PR title becomes the commit message**. Use the same Conventional Commits format for PR titles:
 
 ```
-✨ feat: add inbox watcher polling interval config
-🐛 fix: resolve biome lint errors
+feat: add inbox watcher polling interval config
+fix: resolve biome lint errors
 ```
 
 Use the PR body for details — keep the title short (under 70 characters).


### PR DESCRIPTION
Removes all gitmoji references from CONTRIBUTING.md, CLAUDE.md, and .github/copilot-instructions.md. Conventional Commits only, no emoji prefix.