### PR TITLE
feat(runner): validate provider API key at construction time

### DIFF
--- a/packages/runner/src/provider.ts
+++ b/packages/runner/src/provider.ts
@@ -1,3 +1,4 @@
+import { ProviderAuthError } from "./errors";
 import { AnthropicProvider } from "./providers/anthropic";
 import { EchoProvider } from "./providers/echo";
 import { OllamaProvider } from "./providers/ollama";
@@ -46,14 +47,23 @@ export class ProviderRegistry {
   }
 }
 
-/** Create a registry pre-loaded with all built-in providers. */
+/** Create a registry pre-loaded with all built-in providers.
+ * Providers that require an API key are skipped silently when no key is available. */
 export function createDefaultRegistry(): ProviderRegistry {
   const registry = new ProviderRegistry();
   registry.register("anthropic", new AnthropicProvider());
   registry.register("echo", new EchoProvider());
   registry.register("ollama", new OllamaProvider());
-  registry.register("openai", new OpenAiProvider());
-  registry.register("openrouter", new OpenRouterProvider());
+  for (const [name, factory] of [
+    ["openai", () => new OpenAiProvider()],
+    ["openrouter", () => new OpenRouterProvider()],
+  ] as [string, () => Provider][]) {
+    try {
+      registry.register(name, factory());
+    } catch (e) {
+      if (!(e instanceof ProviderAuthError)) throw e;
+    }
+  }
   return registry;
 }
 

--- a/packages/runner/src/providers/openai.test.ts
+++ b/packages/runner/src/providers/openai.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, expect, test } from "bun:test";
+import { ProviderAuthError } from "../errors";
 import { OpenAiProvider } from "./openai";
 
 const originalFetch = globalThis.fetch;
@@ -87,4 +88,12 @@ test("trailing slash on baseUrl is stripped", async () => {
   const provider = new OpenAiProvider({ apiKey: "sk-test", baseUrl: "https://api.openai.com/" });
   await provider.chat("gpt-4o", "", [{ role: "user", content: "Hi" }]);
   expect(cap.getRequest().url).toBe("https://api.openai.com/v1/chat/completions");
+});
+
+test("throws ProviderAuthError at construction when no key is provided", () => {
+  expect(() => new OpenAiProvider()).toThrow(ProviderAuthError);
+});
+
+test("throws ProviderAuthError at construction when OPENAI_API_KEY env is not set", () => {
+  expect(() => new OpenAiProvider({})).toThrow(ProviderAuthError);
 });

--- a/packages/runner/src/providers/openai.ts
+++ b/packages/runner/src/providers/openai.ts
@@ -1,3 +1,4 @@
+import { ProviderAuthError } from "../errors";
 import { OpenAiCompatibleProvider } from "./openai-compatible";
 
 export interface OpenAiProviderOptions {
@@ -8,7 +9,10 @@ export interface OpenAiProviderOptions {
 /** OpenAI provider using the /v1/chat/completions endpoint. */
 export class OpenAiProvider extends OpenAiCompatibleProvider {
   constructor(options?: OpenAiProviderOptions) {
-    const apiKey = options?.apiKey ?? process.env.OPENAI_API_KEY ?? "";
+    const apiKey = options?.apiKey ?? process.env.OPENAI_API_KEY;
+    if (!apiKey) {
+      throw new ProviderAuthError("openai");
+    }
     super({
       providerName: "openai",
       baseUrl: options?.baseUrl ?? process.env.OPENAI_BASE_URL ?? "https://api.openai.com",

--- a/packages/runner/src/providers/openrouter.test.ts
+++ b/packages/runner/src/providers/openrouter.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, expect, test } from "bun:test";
+import { ProviderAuthError } from "../errors";
 import { OpenRouterProvider } from "./openrouter";
 
 const originalFetch = globalThis.fetch;
@@ -76,4 +77,12 @@ test("X-Title header is sent", async () => {
   await provider.chat("anthropic/claude-sonnet-4-6", "", [{ role: "user", content: "Hi" }]);
   const headers = cap.getRequest().init.headers as Record<string, string>;
   expect(headers["x-title"]).toBe("loom");
+});
+
+test("throws ProviderAuthError at construction when no key is provided", () => {
+  expect(() => new OpenRouterProvider()).toThrow(ProviderAuthError);
+});
+
+test("throws ProviderAuthError at construction when OPENROUTER_API_KEY env is not set", () => {
+  expect(() => new OpenRouterProvider({})).toThrow(ProviderAuthError);
 });

--- a/packages/runner/src/providers/openrouter.ts
+++ b/packages/runner/src/providers/openrouter.ts
@@ -1,3 +1,4 @@
+import { ProviderAuthError } from "../errors";
 import { OpenAiCompatibleProvider } from "./openai-compatible";
 
 export interface OpenRouterProviderOptions {
@@ -7,7 +8,10 @@ export interface OpenRouterProviderOptions {
 /** OpenRouter provider using the OpenAI-compatible /v1/chat/completions endpoint. */
 export class OpenRouterProvider extends OpenAiCompatibleProvider {
   constructor(options?: OpenRouterProviderOptions) {
-    const apiKey = options?.apiKey ?? process.env.OPENROUTER_API_KEY ?? "";
+    const apiKey = options?.apiKey ?? process.env.OPENROUTER_API_KEY;
+    if (!apiKey) {
+      throw new ProviderAuthError("openrouter");
+    }
     super({
       providerName: "openrouter",
       baseUrl: "https://openrouter.ai/api",


### PR DESCRIPTION
Closes #141

`OpenAiProvider` and `OpenRouterProvider` now throw `ProviderAuthError` immediately in the constructor when no API key is found, instead of silently sending an empty `Bearer` token and failing at HTTP call time.

`createDefaultRegistry` is updated to skip providers that lack credentials, so the registry can still be built in environments where only some keys are set.

Tests added for the missing-key case in `openai.test.ts` and `openrouter.test.ts`.