### PR TITLE
feat(runner): add LLM error classification and retry logic

### DIFF
--- a/packages/runner/src/agent-runner.test.ts
+++ b/packages/runner/src/agent-runner.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { AgentProcess, claim, list, read, send, sendReply } from "@losoft/loom-runtime";
 import { AgentRunner } from "./agent-runner";
+import { ProviderAuthError } from "./errors";
 import { type Provider, ProviderRegistry } from "./provider";
 
 let home: string;
@@ -289,7 +290,10 @@ test("provider error: writes error reply to outbox and moves message to .failed/
     },
   } satisfies Provider);
 
-  const runner = new AgentRunner(home, AGENT, registry, { pollIntervalMs: 20 });
+  const runner = new AgentRunner(home, AGENT, registry, {
+    pollIntervalMs: 20,
+    retryBaseDelayMs: 0,
+  });
   const runPromise = runner.run();
 
   // Wait for the error reply to appear in outbox
@@ -317,11 +321,14 @@ test("provider error: .error.json companion contains error details", async () =>
   const registry = new ProviderRegistry();
   registry.register("ollama", {
     chat: async () => {
-      throw new Error("ProviderAuthError: invalid key");
+      throw new ProviderAuthError("openai");
     },
   } satisfies Provider);
 
-  const runner = new AgentRunner(home, AGENT, registry, { pollIntervalMs: 20 });
+  const runner = new AgentRunner(home, AGENT, registry, {
+    pollIntervalMs: 20,
+    retryBaseDelayMs: 0,
+  });
   const runPromise = runner.run();
 
   // Poll until .error.json appears in .failed/ — fail() writes it after sendReply
@@ -349,9 +356,9 @@ test("provider error: .error.json companion contains error details", async () =>
     last_error: string;
     error_type: string;
   };
-  expect(errorJson.last_error).toContain("ProviderAuthError: invalid key");
+  expect(errorJson.last_error).toContain('Authentication failed for provider "openai"');
   expect(errorJson.attempts).toBe(1);
-  expect(errorJson.error_type).toBe("Error");
+  expect(errorJson.error_type).toBe("ProviderAuthError");
 });
 
 test("provider error: drain continues processing next message after failure", async () => {
@@ -365,12 +372,15 @@ test("provider error: drain continues processing next message after failure", as
   registry.register("ollama", {
     chat: async (_model, _system, messages) => {
       callCount++;
-      if (messages[0]!.content === "fail this") throw new Error("forced failure");
+      if (messages[0]!.content === "fail this") throw new ProviderAuthError("openai");
       return { text: "success" };
     },
   } satisfies Provider);
 
-  const runner = new AgentRunner(home, AGENT, registry, { pollIntervalMs: 20 });
+  const runner = new AgentRunner(home, AGENT, registry, {
+    pollIntervalMs: 20,
+    retryBaseDelayMs: 0,
+  });
   const runPromise = runner.run();
 
   // Wait for both outbox messages (error reply + success reply)
@@ -399,4 +409,133 @@ test("stop() halts the polling loop", async () => {
 
   // No messages were sent — outbox should be empty
   expect(await list(join(home, AGENT, "outbox"))).toHaveLength(0);
+});
+
+test("transient error: retries and succeeds, no .failed/ entry", async () => {
+  new AgentProcess(home, AGENT);
+  await send(home, AGENT, "user", "ping");
+
+  let calls = 0;
+  const registry = new ProviderRegistry();
+  registry.register("ollama", {
+    chat: async () => {
+      calls++;
+      if (calls < 3) throw new Error("transient 503");
+      return { text: "recovered" };
+    },
+  } satisfies Provider);
+
+  const runner = new AgentRunner(home, AGENT, registry, {
+    pollIntervalMs: 20,
+    retryBaseDelayMs: 0,
+  });
+  const runPromise = runner.run();
+
+  const outboxDir = join(home, AGENT, "outbox");
+  const outboxFiles = await waitForOutbox(outboxDir);
+  runner.stop();
+  await runPromise;
+
+  const reply = await read(outboxDir, outboxFiles[0]!);
+  expect(reply.body).toBe("recovered");
+  expect(reply.error).toBeFalsy();
+  expect(calls).toBe(3);
+
+  // Nothing in .failed/
+  const inboxDir = join(home, AGENT, "inbox");
+  try {
+    const failedFiles = await readdir(join(inboxDir, ".failed"));
+    expect(failedFiles.filter((f) => f.endsWith(".msg"))).toHaveLength(0);
+  } catch {
+    /* .failed/ doesn't exist — also fine */
+  }
+});
+
+test("transient error exhausted: .error.json records all 3 attempts", async () => {
+  new AgentProcess(home, AGENT);
+  await send(home, AGENT, "user", "trigger");
+
+  const registry = new ProviderRegistry();
+  registry.register("ollama", {
+    chat: async () => {
+      throw new Error("always fails");
+    },
+  } satisfies Provider);
+
+  const runner = new AgentRunner(home, AGENT, registry, {
+    pollIntervalMs: 20,
+    retryBaseDelayMs: 0,
+  });
+  const runPromise = runner.run();
+
+  const inboxDir = join(home, AGENT, "inbox");
+  const failedDir = join(inboxDir, ".failed");
+  let errorFile: string | undefined;
+  const deadline = Date.now() + 2000;
+  while (Date.now() < deadline) {
+    try {
+      const files = await readdir(failedDir);
+      errorFile = files.find((f) => f.endsWith(".error.json"));
+      if (errorFile) break;
+    } catch {
+      /* not yet */
+    }
+    await new Promise<void>((r) => setTimeout(r, 10));
+  }
+  runner.stop();
+  await runPromise;
+
+  expect(errorFile).toBeDefined();
+  const errorJson = JSON.parse(await Bun.file(join(failedDir, errorFile!)).text()) as {
+    attempts: number;
+    last_error: string;
+    error_type: string;
+  };
+  expect(errorJson.attempts).toBe(3);
+  expect(errorJson.last_error).toContain("always fails");
+  expect(errorJson.error_type).toBe("Error");
+});
+
+test("permanent error: fails immediately without retrying", async () => {
+  new AgentProcess(home, AGENT);
+  await send(home, AGENT, "user", "trigger");
+
+  let calls = 0;
+  const registry = new ProviderRegistry();
+  registry.register("ollama", {
+    chat: async () => {
+      calls++;
+      throw new ProviderAuthError("openai");
+    },
+  } satisfies Provider);
+
+  const runner = new AgentRunner(home, AGENT, registry, {
+    pollIntervalMs: 20,
+    retryBaseDelayMs: 0,
+  });
+  const runPromise = runner.run();
+
+  const inboxDir = join(home, AGENT, "inbox");
+  const failedDir = join(inboxDir, ".failed");
+  let errorFile: string | undefined;
+  const deadline = Date.now() + 2000;
+  while (Date.now() < deadline) {
+    try {
+      const files = await readdir(failedDir);
+      errorFile = files.find((f) => f.endsWith(".error.json"));
+      if (errorFile) break;
+    } catch {
+      /* not yet */
+    }
+    await new Promise<void>((r) => setTimeout(r, 10));
+  }
+  runner.stop();
+  await runPromise;
+
+  expect(calls).toBe(1);
+  expect(errorFile).toBeDefined();
+  const errorJson = JSON.parse(await Bun.file(join(failedDir, errorFile!)).text()) as {
+    attempts: number;
+  };
+  expect(errorJson.attempts).toBe(1);
 });

--- a/packages/runner/src/agent-runner.ts
+++ b/packages/runner/src/agent-runner.ts
@@ -10,6 +10,7 @@ import {
   sendReply,
 } from "@losoft/loom-runtime";
 import { type ProviderRegistry, resolveProvider } from "./provider";
+import { RetryExhaustedError, withRetry } from "./retry";
 
 export interface AgentRunnerOptions {
   /** Polling interval in milliseconds (default 200). */
@@ -20,6 +21,8 @@ export interface AgentRunnerOptions {
   onReply?: (text: string) => void;
   /** When set, only process this specific message file and skip crash recovery. */
   targetFilename?: string;
+  /** Base delay in ms for retry backoff (default 1000). Override in tests. */
+  retryBaseDelayMs?: number;
 }
 
 /**
@@ -39,6 +42,7 @@ export class AgentRunner {
   private readonly systemPrompt: string;
   private readonly onReply?: (text: string) => void;
   private readonly targetFilename?: string;
+  private readonly retryBaseDelayMs: number;
   private readonly queue: string[] = [];
   private draining = false;
   private resolveRun: (() => void) | null = null;
@@ -56,6 +60,7 @@ export class AgentRunner {
     this.systemPrompt = options?.systemPrompt ?? "";
     this.onReply = options?.onReply;
     this.targetFilename = options?.targetFilename;
+    this.retryBaseDelayMs = options?.retryBaseDelayMs ?? 1000;
     this.watcher = InboxWatcher.forAgent(home, agentName, {
       pollIntervalMs: options?.pollIntervalMs,
     });
@@ -90,23 +95,29 @@ export class AgentRunner {
 
     try {
       const { provider, modelName } = resolveProvider(this.agent.model, this.registry);
-      const response = await provider.chat(modelName, this.systemPrompt, [
-        { role: "user", content: message.body },
-      ]);
+      const response = await withRetry(
+        () =>
+          provider.chat(modelName, this.systemPrompt, [{ role: "user", content: message.body }]),
+        3,
+        this.retryBaseDelayMs,
+      );
 
       await sendReply(this.home, this.agentName, response.text, origin);
       await acknowledge(this.inboxDir, filename);
       this.agent.status = "idle";
       this.onReply?.(response.text);
     } catch (err) {
-      const errorMessage = err instanceof Error ? err.message : String(err);
-      const errorType = err instanceof Error ? err.constructor.name : "UnknownError";
+      const isExhausted = err instanceof RetryExhaustedError;
+      const cause = isExhausted ? err.cause : err;
+      const attempts = isExhausted ? err.attempts : 1;
+      const errorMessage = cause instanceof Error ? cause.message : String(cause);
+      const errorType = cause instanceof Error ? cause.constructor.name : "UnknownError";
 
       await sendReply(this.home, this.agentName, errorMessage, origin, true);
 
       const failError: FailError = {
         ts: new Date().toISOString(),
-        attempts: 1,
+        attempts,
         last_error: errorMessage,
         error_type: errorType,
       };

--- a/packages/runner/src/retry.test.ts
+++ b/packages/runner/src/retry.test.ts
@@ -1,0 +1,132 @@
+import { expect, test } from "bun:test";
+import { ModelNotFoundError, ProviderAuthError, ToolCallParseError } from "./errors";
+import { classifyError, type ErrorKind, RetryExhaustedError, withRetry } from "./retry";
+
+// ── classifyError ─────────────────────────────────────────────────────────────
+
+test("ProviderAuthError is permanent", () => {
+  expect(classifyError(new ProviderAuthError("openai"))).toBe<ErrorKind>("permanent");
+});
+
+test("ModelNotFoundError is permanent", () => {
+  expect(classifyError(new ModelNotFoundError("openai", "gpt-99"))).toBe<ErrorKind>("permanent");
+});
+
+test("ToolCallParseError is permanent", () => {
+  expect(
+    classifyError(new ToolCallParseError("myTool", "bad json", new SyntaxError())),
+  ).toBe<ErrorKind>("permanent");
+});
+
+test("generic Error is transient", () => {
+  expect(classifyError(new Error("network timeout"))).toBe<ErrorKind>("transient");
+});
+
+test("non-Error values are transient", () => {
+  expect(classifyError("some string error")).toBe<ErrorKind>("transient");
+  expect(classifyError(503)).toBe<ErrorKind>("transient");
+});
+
+// ── withRetry ─────────────────────────────────────────────────────────────────
+
+test("resolves immediately when fn succeeds on first attempt", async () => {
+  let calls = 0;
+  const result = await withRetry(
+    async () => {
+      calls++;
+      return "ok";
+    },
+    3,
+    0,
+  );
+  expect(result).toBe("ok");
+  expect(calls).toBe(1);
+});
+
+test("retries on transient error and succeeds", async () => {
+  let calls = 0;
+  const result = await withRetry(
+    async () => {
+      calls++;
+      if (calls < 3) throw new Error("transient");
+      return "recovered";
+    },
+    3,
+    0,
+  );
+  expect(result).toBe("recovered");
+  expect(calls).toBe(3);
+});
+
+test("throws RetryExhaustedError after maxAttempts transient failures", async () => {
+  let calls = 0;
+  const err = await withRetry(
+    async () => {
+      calls++;
+      throw new Error("always fails");
+    },
+    3,
+    0,
+  ).catch((e) => e);
+
+  expect(err).toBeInstanceOf(RetryExhaustedError);
+  expect((err as RetryExhaustedError).attempts).toBe(3);
+  expect(calls).toBe(3);
+});
+
+test("RetryExhaustedError wraps the original cause", async () => {
+  const original = new Error("original");
+  const err = await withRetry(
+    async () => {
+      throw original;
+    },
+    2,
+    0,
+  ).catch((e) => e);
+  expect(err).toBeInstanceOf(RetryExhaustedError);
+  expect((err as RetryExhaustedError).cause).toBe(original);
+});
+
+test("does not retry on permanent error — fails on first attempt", async () => {
+  let calls = 0;
+  const err = await withRetry(
+    async () => {
+      calls++;
+      throw new ProviderAuthError("openai");
+    },
+    3,
+    0,
+  ).catch((e) => e);
+
+  expect(err).toBeInstanceOf(ProviderAuthError);
+  expect(calls).toBe(1);
+});
+
+test("permanent error is re-thrown directly, not wrapped in RetryExhaustedError", async () => {
+  const err = await withRetry(
+    async () => {
+      throw new ModelNotFoundError("openai", "gpt-99");
+    },
+    3,
+    0,
+  ).catch((e) => e);
+
+  expect(err).toBeInstanceOf(ModelNotFoundError);
+  expect(err).not.toBeInstanceOf(RetryExhaustedError);
+});
+
+test("respects maxAttempts=1 — no retries", async () => {
+  let calls = 0;
+  const err = await withRetry(
+    async () => {
+      calls++;
+      throw new Error("fail");
+    },
+    1,
+    0,
+  ).catch((e) => e);
+
+  expect(err).toBeInstanceOf(RetryExhaustedError);
+  expect((err as RetryExhaustedError).attempts).toBe(1);
+  expect(calls).toBe(1);
+});

--- a/packages/runner/src/retry.ts
+++ b/packages/runner/src/retry.ts
@@ -1,0 +1,58 @@
+import { ModelNotFoundError, ProviderAuthError, ToolCallParseError } from "./errors";
+
+/** Whether an error is worth retrying or should fail immediately. */
+export type ErrorKind = "transient" | "permanent";
+
+/**
+ * Classify an LLM error as transient (retry) or permanent (fail immediately).
+ *
+ * Permanent: auth failures, missing models, malformed tool call arguments.
+ * Transient: everything else — network errors, rate limits, 5xx responses.
+ */
+export function classifyError(err: unknown): ErrorKind {
+  if (err instanceof ProviderAuthError) return "permanent";
+  if (err instanceof ModelNotFoundError) return "permanent";
+  if (err instanceof ToolCallParseError) return "permanent";
+  return "transient";
+}
+
+/** Thrown when all retry attempts are exhausted. Wraps the original error. */
+export class RetryExhaustedError extends Error {
+  constructor(
+    public readonly attempts: number,
+    public override readonly cause: unknown,
+  ) {
+    const msg = cause instanceof Error ? cause.message : String(cause);
+    super(`All ${attempts} attempt(s) failed: ${msg}`);
+    this.name = "RetryExhaustedError";
+  }
+}
+
+/**
+ * Call `fn` with exponential backoff retries for transient errors.
+ *
+ * - Permanent errors are re-thrown immediately (no retry).
+ * - After all retries are exhausted, throws `RetryExhaustedError`.
+ * - Backoff: baseDelayMs * 2^attempt (1s, 2s, 4s by default).
+ */
+export async function withRetry<T>(
+  fn: () => Promise<T>,
+  maxAttempts = 3,
+  baseDelayMs = 1000,
+): Promise<T> {
+  let lastErr: unknown;
+
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      if (classifyError(err) === "permanent") throw err;
+      lastErr = err;
+      if (attempt < maxAttempts - 1) {
+        await new Promise<void>((r) => setTimeout(r, baseDelayMs * 2 ** attempt));
+      }
+    }
+  }
+
+  throw new RetryExhaustedError(maxAttempts, lastErr);
+}


### PR DESCRIPTION
Closes #22

Introduces `retry.ts` with `classifyError()` and `withRetry()`:
- Permanent errors (`ProviderAuthError`, `ModelNotFoundError`, `ToolCallParseError`) fail immediately — no retry
- Transient errors retry up to 3 times with exponential backoff (1s, 2s, 4s)
- Exhausted retries throw `RetryExhaustedError` wrapping the original cause

`AgentRunner.processMessage()` now uses `withRetry()` for all LLM calls. `FailError.attempts` reflects actual attempts made. `retryBaseDelayMs` option added for test overrides.