### PR TITLE
feat(runner): append turn history to conversations/<date>.ndjson

### DIFF
--- a/packages/runner/src/agent-runner.test.ts
+++ b/packages/runner/src/agent-runner.test.ts
@@ -539,3 +539,136 @@ test("permanent error: fails immediately without retrying", async () => {
   };
   expect(errorJson.attempts).toBe(1);
 });
+
+// ── conversation history ──────────────────────────────────────────────────────
+
+test("successful turn appends user and assistant entries to conversations/<date>.ndjson", async () => {
+  new AgentProcess(home, AGENT);
+  await send(home, AGENT, "user", "hello world");
+
+  const replies: string[] = [];
+  let runner!: AgentRunner;
+  await new Promise<void>((resolve) => {
+    runner = new AgentRunner(home, AGENT, makeRegistry("hi there"), {
+      pollIntervalMs: 20,
+      onReply: (text) => {
+        replies.push(text);
+        resolve();
+      },
+    });
+    runner.run().catch(() => {});
+  });
+  runner.stop();
+
+  const conversationsDir = join(home, AGENT, "conversations");
+  const files = (await readdir(conversationsDir)).filter((f) => f.endsWith(".ndjson"));
+  expect(files).toHaveLength(1);
+
+  const lines = (await Bun.file(join(conversationsDir, files[0]!)).text())
+    .trim()
+    .split("\n")
+    .map((l) => JSON.parse(l) as { role: string; content: string; ts: string });
+
+  expect(lines).toHaveLength(2);
+  expect(lines[0]!.role).toBe("user");
+  expect(lines[0]!.content).toBe("hello world");
+  expect(lines[1]!.role).toBe("assistant");
+  expect(lines[1]!.content).toBe("hi there");
+});
+
+test("conversation entries have valid ISO8601 timestamps", async () => {
+  new AgentProcess(home, AGENT);
+  await send(home, AGENT, "user", "ping");
+
+  let runner: AgentRunner;
+  await new Promise<void>((resolve) => {
+    runner = new AgentRunner(home, AGENT, makeRegistry("pong"), {
+      pollIntervalMs: 20,
+      onReply: () => resolve(),
+    });
+    runner.run().catch(() => {});
+  });
+  runner!.stop();
+
+  const conversationsDir = join(home, AGENT, "conversations");
+  const files = (await readdir(conversationsDir)).filter((f) => f.endsWith(".ndjson"));
+  expect(files).toHaveLength(1);
+
+  const lines = (await Bun.file(join(conversationsDir, files[0]!)).text())
+    .trim()
+    .split("\n")
+    .map((l) => JSON.parse(l) as { ts: string });
+
+  for (const line of lines) {
+    expect(new Date(line.ts).toISOString()).toBe(line.ts);
+  }
+});
+
+test("multiple turns append to the same daily file", async () => {
+  new AgentProcess(home, AGENT);
+  await send(home, AGENT, "user", "first");
+  await new Promise<void>((r) => setTimeout(r, 5));
+  await send(home, AGENT, "user", "second");
+
+  let replyCount = 0;
+  let runner: AgentRunner;
+  await new Promise<void>((resolve) => {
+    runner = new AgentRunner(home, AGENT, makeRegistry("reply"), {
+      pollIntervalMs: 20,
+      onReply: () => {
+        replyCount++;
+        if (replyCount >= 2) resolve();
+      },
+    });
+    runner.run().catch(() => {});
+  });
+  runner!.stop();
+
+  const conversationsDir = join(home, AGENT, "conversations");
+  const files = (await readdir(conversationsDir)).filter((f) => f.endsWith(".ndjson"));
+  expect(files).toHaveLength(1);
+
+  const lines = (await Bun.file(join(conversationsDir, files[0]!)).text()).trim().split("\n");
+  expect(lines).toHaveLength(4); // 2 turns × 2 lines each
+});
+
+test("failed turn does not append to conversation history", async () => {
+  new AgentProcess(home, AGENT);
+  await send(home, AGENT, "user", "trigger failure");
+
+  const registry = new ProviderRegistry();
+  registry.register("ollama", {
+    chat: async () => {
+      throw new ProviderAuthError("openai");
+    },
+  } satisfies Provider);
+
+  const runner = new AgentRunner(home, AGENT, registry, {
+    pollIntervalMs: 20,
+    retryBaseDelayMs: 0,
+  });
+  const runPromise = runner.run();
+
+  // Poll until .error.json appears — ensures fail() has fully completed
+  const failedDir = join(home, AGENT, "inbox", ".failed");
+  const deadline = Date.now() + 2000;
+  while (Date.now() < deadline) {
+    try {
+      const files = await readdir(failedDir);
+      if (files.some((f) => f.endsWith(".error.json"))) break;
+    } catch {
+      /* not yet */
+    }
+    await new Promise<void>((r) => setTimeout(r, 10));
+  }
+  runner.stop();
+  await runPromise;
+
+  const conversationsDir = join(home, AGENT, "conversations");
+  try {
+    const files = await readdir(conversationsDir);
+    expect(files.filter((f) => f.endsWith(".ndjson"))).toHaveLength(0);
+  } catch {
+    /* conversations/ may not exist yet — also fine */
+  }
+});

--- a/packages/runner/src/agent-runner.ts
+++ b/packages/runner/src/agent-runner.ts
@@ -1,3 +1,4 @@
+import { appendFile } from "node:fs/promises";
 import { join } from "node:path";
 import {
   AgentProcess,
@@ -11,6 +12,22 @@ import {
 } from "@losoft/loom-runtime";
 import { type ProviderRegistry, resolveProvider } from "./provider";
 import { RetryExhaustedError, withRetry } from "./retry";
+
+/** Append a user+assistant turn to the agent's daily conversation file. */
+async function appendConversationTurn(
+  conversationsDir: string,
+  userContent: string,
+  userTs: string,
+  assistantContent: string,
+  assistantTs: string,
+): Promise<void> {
+  const date = new Intl.DateTimeFormat("en-CA").format(new Date());
+  const filePath = join(conversationsDir, `${date}.ndjson`);
+  const lines =
+    `${JSON.stringify({ role: "user", content: userContent, ts: userTs })}\n` +
+    `${JSON.stringify({ role: "assistant", content: assistantContent, ts: assistantTs })}\n`;
+  await appendFile(filePath, lines, "utf8");
+}
 
 export interface AgentRunnerOptions {
   /** Polling interval in milliseconds (default 200). */
@@ -94,6 +111,7 @@ export class AgentRunner {
     const origin = message.origin ? `${message.origin}/${filename}` : filename;
 
     try {
+      const userTs = new Date().toISOString();
       const { provider, modelName } = resolveProvider(this.agent.model, this.registry);
       const response = await withRetry(
         () =>
@@ -101,9 +119,17 @@ export class AgentRunner {
         3,
         this.retryBaseDelayMs,
       );
+      const assistantTs = new Date().toISOString();
 
       await sendReply(this.home, this.agentName, response.text, origin);
       await acknowledge(this.inboxDir, filename);
+      await appendConversationTurn(
+        join(this.home, this.agentName, "conversations"),
+        message.body,
+        userTs,
+        response.text,
+        assistantTs,
+      );
       this.agent.status = "idle";
       this.onReply?.(response.text);
     } catch (err) {


### PR DESCRIPTION
Closes #133

Each successful agent turn now appends two NDJSON lines to `conversations/YYYY-MM-DD.ndjson` — one for the user message and one for the assistant response, both with ISO 8601 timestamps.

Failed turns (provider errors) are not written to history.

## Changes
- `agent-runner.ts`: added `appendConversationTurn()` helper; updated `processMessage()` to capture timestamps and call it after `acknowledge()`
- `agent-runner.test.ts`: 4 new tests covering success, timestamps, multi-turn accumulation, and failure exclusion