### PR TITLE
feat(cli): implement loom agent stop command

### DIFF
--- a/packages/cli/src/commands/stop.test.ts
+++ b/packages/cli/src/commands/stop.test.ts
@@ -1,0 +1,111 @@
+/// <reference types="bun" />
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { AgentProcess } from "@losoft/loom-runtime";
+import { stop } from "./stop";
+
+let loomHome: string;
+const AGENT = "test-agent";
+
+beforeEach(() => {
+  loomHome = mkdtempSync(join(tmpdir(), "loom-home-"));
+});
+
+afterEach(() => {
+  rmSync(loomHome, { recursive: true, force: true });
+});
+
+// ── arg validation ────────────────────────────────────────────────────────────
+
+test("throws when agent name is missing", async () => {
+  await expect(stop([], loomHome)).rejects.toThrow("Usage:");
+});
+
+// ── no running process ────────────────────────────────────────────────────────
+
+test("marks status stopped when agent has no PID", async () => {
+  const agentsRoot = join(loomHome, "agents");
+  const agent = new AgentProcess(agentsRoot, AGENT);
+  agent.status = "idle";
+
+  await stop([AGENT], loomHome);
+
+  expect(agent.status).toBe("stopped");
+  expect(agent.stoppedAt).toBeTruthy();
+  expect(agent.pid).toBeNull();
+});
+
+test("marks status stopped when PID points to a dead process", async () => {
+  const agentsRoot = join(loomHome, "agents");
+  const agent = new AgentProcess(agentsRoot, AGENT);
+  agent.pid = 999_999_999; // almost certainly not a real PID
+
+  await stop([AGENT], loomHome);
+
+  expect(agent.status).toBe("stopped");
+  expect(agent.pid).toBeNull();
+});
+
+// ── SIGTERM ───────────────────────────────────────────────────────────────────
+
+test("sends SIGTERM and waits for process to exit", async () => {
+  // Spawn a long-running process
+  const proc = Bun.spawn(["/usr/bin/sleep", "60"]);
+  const pid = proc.pid;
+
+  const agentsRoot = join(loomHome, "agents");
+  const agent = new AgentProcess(agentsRoot, AGENT);
+  agent.pid = pid;
+  agent.status = "running";
+
+  await stop([AGENT], loomHome, { sigtermTimeoutMs: 2000 });
+
+  expect(agent.status).toBe("stopped");
+  expect(agent.pid).toBeNull();
+  expect(agent.stoppedAt).toBeTruthy();
+
+  // Verify the process is actually dead
+  let alive = true;
+  try {
+    process.kill(pid, 0);
+  } catch {
+    alive = false;
+  }
+  expect(alive).toBe(false);
+});
+
+// ── SIGKILL escalation ────────────────────────────────────────────────────────
+
+test("escalates to SIGKILL when process ignores SIGTERM", async () => {
+  // Spawn a shell that traps and ignores SIGTERM
+  const proc = Bun.spawn([
+    "/usr/bin/bash",
+    "-c",
+    "trap '' TERM; while true; do /usr/bin/sleep 0.1; done",
+  ]);
+  const pid = proc.pid;
+
+  // Give the shell a moment to set up the trap
+  await new Promise<void>((r) => setTimeout(r, 100));
+
+  const agentsRoot = join(loomHome, "agents");
+  const agent = new AgentProcess(agentsRoot, AGENT);
+  agent.pid = pid;
+  agent.status = "running";
+
+  // Use a short SIGTERM timeout so the test doesn't take 10 seconds
+  await stop([AGENT], loomHome, { sigtermTimeoutMs: 300 });
+
+  expect(agent.status).toBe("stopped");
+  expect(agent.pid).toBeNull();
+
+  let alive = true;
+  try {
+    process.kill(pid, 0);
+  } catch {
+    alive = false;
+  }
+  expect(alive).toBe(false);
+});

--- a/packages/cli/src/commands/stop.ts
+++ b/packages/cli/src/commands/stop.ts
@@ -1,4 +1,63 @@
-/** Stop a specific agent. */
-export async function stop(_args: string[], _loomHome: string): Promise<void> {
-  console.log("loom stop — not yet implemented");
+import { join } from "node:path";
+import { AgentProcess } from "@losoft/loom-runtime";
+
+const SIGTERM_TIMEOUT_MS = 10_000;
+const POLL_INTERVAL_MS = 50;
+
+export interface StopOptions {
+  /** How long to wait for SIGTERM before escalating to SIGKILL (default 10000ms). */
+  sigtermTimeoutMs?: number;
+}
+
+/** Returns true if a process with the given PID is alive. */
+function isAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Poll until `pid` exits or `timeoutMs` elapses. Returns true if the process is dead. */
+async function waitForDeath(pid: number, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!isAlive(pid)) return true;
+    await new Promise<void>((r) => setTimeout(r, POLL_INTERVAL_MS));
+  }
+  return !isAlive(pid);
+}
+
+/** Stop a specific agent. Sends SIGTERM; escalates to SIGKILL after timeout. */
+export async function stop(args: string[], loomHome: string, options?: StopOptions): Promise<void> {
+  const name = args.find((a) => !a.startsWith("-"));
+  if (!name) {
+    throw new Error("Usage: loom agent stop <name>");
+  }
+
+  const agentsRoot = join(loomHome, "agents");
+  const agent = new AgentProcess(agentsRoot, name);
+
+  // Mark stopped immediately so the supervisor does not restart the agent
+  agent.status = "stopped";
+  agent.stoppedAt = new Date().toISOString();
+
+  const pid = agent.pid;
+  if (pid === null || !isAlive(pid)) {
+    agent.pid = null;
+    return;
+  }
+
+  process.kill(pid, "SIGTERM");
+
+  const sigtermTimeout = options?.sigtermTimeoutMs ?? SIGTERM_TIMEOUT_MS;
+  const died = await waitForDeath(pid, sigtermTimeout);
+
+  if (!died) {
+    process.kill(pid, "SIGKILL");
+    await waitForDeath(pid, sigtermTimeout);
+  }
+
+  agent.pid = null;
 }


### PR DESCRIPTION
Closes #34

- Writes `status: stopped` immediately (supervisor will not restart)
- Reads PID from agent state; no-op if process is already dead
- Sends SIGTERM and polls for exit
- Escalates to SIGKILL after timeout (default 10s) if process does not exit
- Clears PID from agent state after shutdown