### PR TITLE
fix(cli): remove status pre-assignments that caused TS literal narrowing in stop tests

### DIFF
--- a/packages/cli/src/commands/stop.test.ts
+++ b/packages/cli/src/commands/stop.test.ts
@@ -28,7 +28,6 @@ test("throws when agent name is missing", async () => {
 test("marks status stopped when agent has no PID", async () => {
   const agentsRoot = join(loomHome, "agents");
   const agent = new AgentProcess(agentsRoot, AGENT);
-  agent.status = "idle";
 
   await stop([AGENT], loomHome);
 
@@ -58,7 +57,6 @@ test("sends SIGTERM and waits for process to exit", async () => {
   const agentsRoot = join(loomHome, "agents");
   const agent = new AgentProcess(agentsRoot, AGENT);
   agent.pid = pid;
-  agent.status = "running";
 
   await stop([AGENT], loomHome, { sigtermTimeoutMs: 2000 });
 
@@ -93,7 +91,6 @@ test("escalates to SIGKILL when process ignores SIGTERM", async () => {
   const agentsRoot = join(loomHome, "agents");
   const agent = new AgentProcess(agentsRoot, AGENT);
   agent.pid = pid;
-  agent.status = "running";
 
   // Use a short SIGTERM timeout so the test doesn't take 10 seconds
   await stop([AGENT], loomHome, { sigtermTimeoutMs: 300 });


### PR DESCRIPTION
Fixes CI failure from #158. Bun's typed `expect` infers the literal type from the last assignment — so `agent.status = "idle"` followed by `expect(agent.status).toBe("stopped")` failed `tsc`. Removed the unnecessary pre-assignments (stop only looks at PID, not initial status).