### PR TITLE
fix(runner): swallow appendConversationTurn errors to prevent message flow disruption

### DIFF
--- a/packages/cli/src/commands/stop.test.ts
+++ b/packages/cli/src/commands/stop.test.ts
@@ -28,7 +28,6 @@ test("throws when agent name is missing", async () => {
 test("marks status stopped when agent has no PID", async () => {
   const agentsRoot = join(loomHome, "agents");
   const agent = new AgentProcess(agentsRoot, AGENT);
-  agent.status = "idle";
 
   await stop([AGENT], loomHome);
 
@@ -58,7 +57,6 @@ test("sends SIGTERM and waits for process to exit", async () => {
   const agentsRoot = join(loomHome, "agents");
   const agent = new AgentProcess(agentsRoot, AGENT);
   agent.pid = pid;
-  agent.status = "running";
 
   await stop([AGENT], loomHome, { sigtermTimeoutMs: 2000 });
 
@@ -93,7 +91,6 @@ test("escalates to SIGKILL when process ignores SIGTERM", async () => {
   const agentsRoot = join(loomHome, "agents");
   const agent = new AgentProcess(agentsRoot, AGENT);
   agent.pid = pid;
-  agent.status = "running";
 
   // Use a short SIGTERM timeout so the test doesn't take 10 seconds
   await stop([AGENT], loomHome, { sigtermTimeoutMs: 300 });

--- a/packages/runner/src/agent-runner.ts
+++ b/packages/runner/src/agent-runner.ts
@@ -123,13 +123,17 @@ export class AgentRunner {
 
       await sendReply(this.home, this.agentName, response.text, origin);
       await acknowledge(this.inboxDir, filename);
-      await appendConversationTurn(
-        join(this.home, this.agentName, "conversations"),
-        message.body,
-        userTs,
-        response.text,
-        assistantTs,
-      );
+      try {
+        await appendConversationTurn(
+          join(this.home, this.agentName, "conversations"),
+          message.body,
+          userTs,
+          response.text,
+          assistantTs,
+        );
+      } catch {
+        // History write failure must not affect message processing
+      }
       this.agent.status = "idle";
       this.onReply?.(response.text);
     } catch (err) {


### PR DESCRIPTION
History write failures were propagating into the catch block, which tried to move an already-acknowledged message from `.in-progress` → `.failed/` — ENOENT since the message was already in `.processed`. History writes are best-effort and must not affect message processing.