### PR TITLE
test(supervisor): add unit tests for computebackoff and ismaxrestartsexceeded

### DIFF
--- a/packages/supervisor/src/restart.test.ts
+++ b/packages/supervisor/src/restart.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+import { computeBackoff, isMaxRestartsExceeded } from "./restart";
+
+describe("computeBackoff", () => {
+  test("restartCount 0 returns value between 1000-1500ms", () => {
+    const result = computeBackoff(0);
+    expect(result).toBeGreaterThanOrEqual(1000);
+    expect(result).toBeLessThanOrEqual(1500);
+  });
+
+  test("caps at maxBackoffMs for high restart counts", () => {
+    const result = computeBackoff(20);
+    expect(result).toBeGreaterThanOrEqual(300000);
+    expect(result).toBeLessThanOrEqual(300500);
+  });
+
+  test("jitter is between 0-500ms", () => {
+    for (let i = 0; i < 50; i++) {
+      const result = computeBackoff(0);
+      const jitter = result - 1000;
+      expect(jitter).toBeGreaterThanOrEqual(0);
+      expect(jitter).toBeLessThanOrEqual(500);
+    }
+  });
+});
+
+describe("isMaxRestartsExceeded", () => {
+  test("returns false when restartCount < 10", () => {
+    expect(isMaxRestartsExceeded(0)).toBe(false);
+    expect(isMaxRestartsExceeded(5)).toBe(false);
+    expect(isMaxRestartsExceeded(9)).toBe(false);
+  });
+
+  test("returns true when restartCount >= 10", () => {
+    expect(isMaxRestartsExceeded(10)).toBe(true);
+    expect(isMaxRestartsExceeded(15)).toBe(true);
+  });
+});


### PR DESCRIPTION
## 🚀 New Feature

### Problem
Create a new test file `packages/supervisor/src/restart.test.ts` to cover the `computeBackoff()` and `isMaxRestartsExceeded()` functions. The tests must verify: (1) `computeBackoff(0)` returns a value between 1000-1500ms (baseDelayMs + 0-500ms jitter), (2) backoff values cap at `maxBackoffMs` for high attempt numbers, (3) jitter calculation by subtracting base delay shows 0-500ms range, and (4) `isMaxRestartsExceeded` returns true for count >= 10 and false for count < 10 using default options (where maxRestarts defaults to 10).

**Severity**: `low`
**File**: `packages/supervisor/src/restart.test.ts`

### Solution
Create `packages/supervisor/src/restart.test.ts` with the following Bun test implementation:

### Changes
- `packages/supervisor/src/restart.test.ts` (new)

## Summary


## Test plan

- [ ] `bun run check` passes
- [ ] `bun run build` passes
- [ ] `bun test` passes

---

<details>
<summary>🤖 About this PR</summary>

This pull request was generated by [ContribAI](https://github.com/tang-vu/ContribAI), an AI agent
that helps improve open source projects. The change was:

1. **Discovered** by automated code analysis
2. **Generated** by AI with context-aware code generation
3. **Self-reviewed** by AI quality checks

If you have questions or feedback about this PR, please comment below.
We appreciate your time reviewing this contribution!

</details>


Closes #129