### PR TITLE
feat(runner): implement PipeRunner with command operator

### DIFF
--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -1,6 +1,13 @@
 export { AgentRunner, type AgentRunnerOptions } from "./agent-runner";
 export { ModelNotFoundError, ProviderAuthError } from "./errors";
 export {
+  type CommandOperatorConfig,
+  type OperatorConfig,
+  type PipeConfig,
+  PipeRunner,
+  type PipeRunnerOptions,
+} from "./pipe-runner";
+export {
   type ChatMessage,
   type ChatResponse,
   createDefaultRegistry,

--- a/packages/runner/src/pipe-runner.test.ts
+++ b/packages/runner/src/pipe-runner.test.ts
@@ -73,7 +73,7 @@ test("passes message through a single command operator (cat) to outbox", async (
   expect(outboxFiles).toHaveLength(1);
   const msg = await read(join(instanceDir, "outbox"), outboxFiles[0]!);
   expect(msg.body).toBe('{"value":42}');
-  expect(msg.from).toBe(instanceDir.split("/").pop());
+  expect(msg.from).toBe(instanceDir.split("/").at(-1) ?? "");
   expect(msg.v).toBe(1);
 });
 

--- a/packages/runner/src/pipe-runner.test.ts
+++ b/packages/runner/src/pipe-runner.test.ts
@@ -1,0 +1,280 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { mkdtemp, readdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { atomicWrite, list, type Message, read } from "@losoft/loom-runtime";
+import { type PipeConfig, PipeRunner } from "./pipe-runner";
+
+let instanceDir: string;
+let inboxDir: string;
+
+beforeEach(async () => {
+  instanceDir = await mkdtemp(join(tmpdir(), "pipe-runner-test-"));
+  inboxDir = join(instanceDir, "inbox");
+  await Bun.write(join(inboxDir, ".keep"), "");
+});
+
+afterEach(async () => {
+  await rm(instanceDir, { recursive: true, force: true });
+});
+
+/** Write a message directly to the instance inbox. */
+async function writeInbox(body: string, origin?: string): Promise<string> {
+  const ts = Date.now();
+  const id = crypto.randomUUID().replace(/-/g, "").slice(0, 16);
+  const filename = `${ts}-${id}.msg`;
+  const msg: Message = { v: 1, id, from: "test-agent", ts, body, ...(origin ? { origin } : {}) };
+  await atomicWrite(join(inboxDir, filename), JSON.stringify(msg, null, 2));
+  return filename;
+}
+
+/** Poll until dir has at least count .msg files, or throw on timeout. */
+async function waitForFiles(dir: string, count = 1, timeout = 2000): Promise<string[]> {
+  const deadline = Date.now() + timeout;
+  while (Date.now() < deadline) {
+    const files = await readdir(dir).catch(() => [] as string[]);
+    const msgs = files.filter((f) => f.endsWith(".msg"));
+    if (msgs.length >= count) return msgs;
+    await Bun.sleep(10);
+  }
+  throw new Error(`Timed out waiting for ${count} .msg file(s) in ${dir}`);
+}
+
+/** Poll until inbox/.processed has at least one file. */
+async function waitForProcessed(timeout = 2000): Promise<void> {
+  const deadline = Date.now() + timeout;
+  while (Date.now() < deadline) {
+    const files = await readdir(join(inboxDir, ".processed")).catch(() => [] as string[]);
+    if (files.length > 0) return;
+    await Bun.sleep(10);
+  }
+  throw new Error("Timed out waiting for message to be processed");
+}
+
+function makeRunner(config: PipeConfig): { runner: PipeRunner; runPromise: Promise<void> } {
+  const runner = new PipeRunner(instanceDir, config, { pollIntervalMs: 20 });
+  const runPromise = runner.run();
+  return { runner, runPromise };
+}
+
+// ── Basic flow ────────────────────────────────────────────────────────────
+
+test("passes message through a single command operator (cat) to outbox", async () => {
+  await writeInbox('{"value":42}');
+
+  const { runner, runPromise } = makeRunner({
+    operators: [{ operator: "command", cmd: "cat" }],
+  });
+
+  const outboxFiles = await waitForFiles(join(instanceDir, "outbox"));
+  runner.stop();
+  await runPromise;
+
+  expect(outboxFiles).toHaveLength(1);
+  const msg = await read(join(instanceDir, "outbox"), outboxFiles[0]!);
+  expect(msg.body).toBe('{"value":42}');
+  expect(msg.from).toBe(instanceDir.split("/").pop());
+  expect(msg.v).toBe(1);
+});
+
+test("writes intermediate result to steps/0/", async () => {
+  await writeInbox("hello");
+
+  const { runner, runPromise } = makeRunner({
+    operators: [{ operator: "command", cmd: "cat" }],
+  });
+
+  await waitForFiles(join(instanceDir, "outbox"));
+  runner.stop();
+  await runPromise;
+
+  const stepFiles = await readdir(join(instanceDir, "steps", "0")).catch(() => [] as string[]);
+  expect(stepFiles.filter((f) => f.endsWith(".msg"))).toHaveLength(1);
+
+  const stepMsg = await read(
+    join(instanceDir, "steps", "0"),
+    stepFiles.filter((f) => f.endsWith(".msg"))[0]!,
+  );
+  expect(stepMsg.body).toBe("hello");
+});
+
+test("chains two operators and writes steps for each", async () => {
+  await writeInbox("hello world");
+
+  const { runner, runPromise } = makeRunner({
+    operators: [
+      { operator: "command", cmd: "cat" }, // step 0: echo through
+      { operator: "command", cmd: "tr a-z A-Z" }, // step 1: uppercase
+    ],
+  });
+
+  await waitForFiles(join(instanceDir, "outbox"));
+  runner.stop();
+  await runPromise;
+
+  const outboxFiles = await waitForFiles(join(instanceDir, "outbox"));
+  const msg = await read(join(instanceDir, "outbox"), outboxFiles[0]!);
+  expect(msg.body).toBe("HELLO WORLD");
+
+  const step0 = await readdir(join(instanceDir, "steps", "0"));
+  const step1 = await readdir(join(instanceDir, "steps", "1"));
+  expect(step0.filter((f) => f.endsWith(".msg"))).toHaveLength(1);
+  expect(step1.filter((f) => f.endsWith(".msg"))).toHaveLength(1);
+});
+
+// ── Drop semantics ────────────────────────────────────────────────────────
+
+test("drops message when command exits non-zero — no outbox, message acknowledged", async () => {
+  await writeInbox("{}");
+
+  const { runner, runPromise } = makeRunner({
+    operators: [{ operator: "command", cmd: "exit 1" }],
+  });
+
+  await waitForProcessed();
+  runner.stop();
+  await runPromise;
+
+  const outboxFiles = await readdir(join(instanceDir, "outbox")).catch(() => [] as string[]);
+  expect(outboxFiles.filter((f) => f.endsWith(".msg"))).toHaveLength(0);
+
+  const processed = await readdir(join(inboxDir, ".processed"));
+  expect(processed).toHaveLength(1);
+});
+
+test("drops message when command produces no output", async () => {
+  await writeInbox("{}");
+
+  const { runner, runPromise } = makeRunner({
+    operators: [{ operator: "command", cmd: "true" }], // exits 0 but no stdout
+  });
+
+  await waitForProcessed();
+  runner.stop();
+  await runPromise;
+
+  const outboxFiles = await readdir(join(instanceDir, "outbox")).catch(() => [] as string[]);
+  expect(outboxFiles.filter((f) => f.endsWith(".msg"))).toHaveLength(0);
+});
+
+test("short-circuits chain on first drop — does not run subsequent operators", async () => {
+  await writeInbox("{}");
+
+  const _op1Ran = false;
+  const { runner, runPromise } = makeRunner({
+    operators: [
+      { operator: "command", cmd: "exit 1" }, // drops
+      { operator: "command", cmd: "echo ran" }, // should not run
+    ],
+  });
+
+  await waitForProcessed();
+  runner.stop();
+  await runPromise;
+
+  // If step 1 directory exists with messages, op1 ran (it shouldn't)
+  const step1Files = await readdir(join(instanceDir, "steps", "1")).catch(() => [] as string[]);
+  expect(step1Files.filter((f) => f.endsWith(".msg"))).toHaveLength(0);
+});
+
+// ── Multi-line output (fan-out) ───────────────────────────────────────────
+
+test("produces one outbox message per stdout line", async () => {
+  await writeInbox("input");
+
+  const { runner, runPromise } = makeRunner({
+    operators: [{ operator: "command", cmd: 'printf "line1\\nline2\\nline3"' }],
+  });
+
+  const outboxFiles = await waitForFiles(join(instanceDir, "outbox"), 3);
+  runner.stop();
+  await runPromise;
+
+  expect(outboxFiles).toHaveLength(3);
+});
+
+// ── Origin propagation ────────────────────────────────────────────────────
+
+test("prepends incoming filename to origin on outbox message", async () => {
+  const filename = await writeInbox("test", "upstream-ts-abc.msg");
+
+  const { runner, runPromise } = makeRunner({
+    operators: [{ operator: "command", cmd: "cat" }],
+  });
+
+  const outboxFiles = await waitForFiles(join(instanceDir, "outbox"));
+  runner.stop();
+  await runPromise;
+
+  const msg = await read(join(instanceDir, "outbox"), outboxFiles[0]!);
+  expect(msg.origin).toBe(`upstream-ts-abc.msg/${filename}`);
+});
+
+test("sets origin from filename when incoming message has no origin", async () => {
+  const filename = await writeInbox("no-origin-msg");
+
+  const { runner, runPromise } = makeRunner({
+    operators: [{ operator: "command", cmd: "cat" }],
+  });
+
+  const outboxFiles = await waitForFiles(join(instanceDir, "outbox"));
+  runner.stop();
+  await runPromise;
+
+  const msg = await read(join(instanceDir, "outbox"), outboxFiles[0]!);
+  expect(msg.origin).toBe(filename);
+});
+
+// ── Status file ───────────────────────────────────────────────────────────
+
+test("writes idle to status file after processing", async () => {
+  await writeInbox("{}");
+
+  const { runner, runPromise } = makeRunner({
+    operators: [{ operator: "command", cmd: "cat" }],
+  });
+
+  await waitForFiles(join(instanceDir, "outbox"));
+  runner.stop();
+  await runPromise;
+
+  const status = await Bun.file(join(instanceDir, "status")).text();
+  expect(status).toBe("idle");
+});
+
+// ── Inbox lifecycle ───────────────────────────────────────────────────────
+
+test("moves processed message out of inbox", async () => {
+  await writeInbox("{}");
+
+  const { runner, runPromise } = makeRunner({
+    operators: [{ operator: "command", cmd: "cat" }],
+  });
+
+  await waitForFiles(join(instanceDir, "outbox"));
+  runner.stop();
+  await runPromise;
+
+  const remaining = await list(inboxDir);
+  expect(remaining).toHaveLength(0);
+
+  const processed = await readdir(join(inboxDir, ".processed"));
+  expect(processed).toHaveLength(1);
+});
+
+test("processes multiple messages sequentially", async () => {
+  await writeInbox("first");
+  await writeInbox("second");
+  await writeInbox("third");
+
+  const { runner, runPromise } = makeRunner({
+    operators: [{ operator: "command", cmd: "cat" }],
+  });
+
+  await waitForFiles(join(instanceDir, "outbox"), 3);
+  runner.stop();
+  await runPromise;
+
+  const outboxFiles = await readdir(join(instanceDir, "outbox"));
+  expect(outboxFiles.filter((f) => f.endsWith(".msg"))).toHaveLength(3);
+});

--- a/packages/runner/src/pipe-runner.ts
+++ b/packages/runner/src/pipe-runner.ts
@@ -1,0 +1,293 @@
+/**
+ * @file PipeRunner — drives a pipe instance: polls inbox, executes operator chain, writes steps + outbox.
+ * @module @loom/runner/pipe-runner
+ *
+ * Each message is claimed from inbox/, run through the operator chain step by step,
+ * with intermediate results written to steps/N/. The final step output is written
+ * to outbox/. Drop (non-zero exit) short-circuits the chain without writing to outbox.
+ * Unrecoverable errors write a failure reply to outbox and move the original to .failed/.
+ *
+ * @see ADR-010
+ */
+
+import { mkdir } from "node:fs/promises";
+import { basename, join } from "node:path";
+import {
+  acknowledge,
+  atomicWrite,
+  claim,
+  type FailError,
+  fail,
+  InboxWatcher,
+  type InboxWatcherOptions,
+  type Message,
+} from "@losoft/loom-runtime";
+
+// ── Operator types ─────────────────────────────────────────────────────────
+
+export interface CommandOperatorConfig {
+  operator: "command";
+  /** Shell command to run. stdin = message body. stdout lines = output messages. */
+  cmd: string;
+  /** Timeout in ms before the command is killed and the message is forwarded unchanged (default: 30_000). */
+  timeoutMs?: number;
+}
+
+/** Union of all operator config types (extended as new operators are added). */
+export type OperatorConfig = CommandOperatorConfig;
+
+export interface PipeConfig {
+  operators: OperatorConfig[];
+}
+
+// ── PipeRunner ─────────────────────────────────────────────────────────────
+
+export interface PipeRunnerOptions {
+  /** Polling interval for the inbox watcher in ms (default: 200). */
+  pollIntervalMs?: number;
+}
+
+/**
+ * Drives a single pipe instance.
+ *
+ * Polls the instance's `inbox/`, runs each message through the configured
+ * operator chain, writes intermediate results to `steps/N/`, and writes
+ * final results to `outbox/`.
+ */
+export class PipeRunner {
+  private readonly instanceName: string;
+  private readonly inboxDir: string;
+  private readonly outboxDir: string;
+  private readonly stepsDir: string;
+  private readonly statusFile: string;
+  private readonly watcher: InboxWatcher;
+  private readonly queue: string[] = [];
+  private draining = false;
+  private stopped = false;
+  private resolveRun: (() => void) | null = null;
+
+  constructor(
+    readonly instanceDir: string,
+    private readonly config: PipeConfig,
+    options?: PipeRunnerOptions,
+  ) {
+    this.instanceName = basename(instanceDir);
+    this.inboxDir = join(instanceDir, "inbox");
+    this.outboxDir = join(instanceDir, "outbox");
+    this.stepsDir = join(instanceDir, "steps");
+    this.statusFile = join(instanceDir, "status");
+
+    const watcherOpts: InboxWatcherOptions = { pollIntervalMs: options?.pollIntervalMs };
+    this.watcher = new InboxWatcher(this.inboxDir, watcherOpts);
+    this.watcher.on("message", (filename) => {
+      this.queue.push(filename);
+      this.drain().catch(() => {});
+    });
+  }
+
+  /** Start the pipe loop. Returns a Promise that resolves when stop() is called. */
+  async run(): Promise<void> {
+    if (this.stopped) return;
+    this.watcher.start();
+    return new Promise<void>((resolve) => {
+      this.resolveRun = resolve;
+    });
+  }
+
+  /** Stop the polling loop. */
+  stop(): void {
+    this.stopped = true;
+    this.watcher.stop();
+    this.resolveRun?.();
+    this.resolveRun = null;
+  }
+
+  private async drain(): Promise<void> {
+    if (this.draining) return;
+    this.draining = true;
+    try {
+      while (this.queue.length > 0) {
+        const filename = this.queue.shift();
+        if (filename !== undefined) await this.processMessage(filename);
+      }
+    } finally {
+      this.draining = false;
+    }
+  }
+
+  /** Process a single message through the full operator chain. */
+  private async processMessage(filename: string): Promise<void> {
+    const message = await claim(this.inboxDir, filename);
+    await this.setStatus("running");
+
+    const origin = message.origin ? `${message.origin}/${filename}` : filename;
+
+    try {
+      let currentBodies: string[] = [message.body];
+
+      for (let i = 0; i < this.config.operators.length; i++) {
+        // biome-ignore lint/style/noNonNullAssertion: i is within bounds, checked by loop condition
+        const op = this.config.operators[i]!;
+        const nextBodies: string[] = [];
+
+        for (const body of currentBodies) {
+          const result = await this.runOperator(op, body);
+          if (result === null) {
+            // Drop — short-circuit the entire chain
+            await acknowledge(this.inboxDir, filename);
+            await this.setStatus("idle");
+            return;
+          }
+          nextBodies.push(...result);
+        }
+
+        // Write step outputs
+        const stepDir = join(this.stepsDir, String(i));
+        await mkdir(stepDir, { recursive: true });
+        for (const body of nextBodies) {
+          await this.writeMessage(stepDir, body, origin);
+        }
+
+        currentBodies = nextBodies;
+
+        if (currentBodies.length === 0) {
+          // All outputs dropped
+          await acknowledge(this.inboxDir, filename);
+          await this.setStatus("idle");
+          return;
+        }
+      }
+
+      // Write final results to outbox
+      await mkdir(this.outboxDir, { recursive: true });
+      for (const body of currentBodies) {
+        await this.writeMessage(this.outboxDir, body, origin);
+      }
+
+      await acknowledge(this.inboxDir, filename);
+      await this.setStatus("idle");
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : String(err);
+      const errorType = err instanceof Error ? err.constructor.name : "UnknownError";
+
+      // Write failure reply to outbox
+      await mkdir(this.outboxDir, { recursive: true });
+      await this.writeMessage(this.outboxDir, errorMessage, origin, true);
+
+      const failError: FailError = {
+        ts: new Date().toISOString(),
+        attempts: 1,
+        last_error: errorMessage,
+        error_type: errorType,
+      };
+      await fail(this.inboxDir, filename, failError);
+      await this.setStatus("idle");
+    }
+  }
+
+  /** Dispatch to the correct operator implementation. */
+  private async runOperator(op: OperatorConfig, body: string): Promise<string[] | null> {
+    if (op.operator === "command") {
+      return this.runCommandOperator(op, body);
+    }
+    // Unknown operator type — forward unchanged (fail-safe)
+    return [body];
+  }
+
+  /**
+   * Run a command operator.
+   *
+   * - stdin: message body
+   * - stdout: each non-empty line becomes a separate output message body
+   * - exit 0 with output: forward
+   * - exit non-zero: drop (return null)
+   * - crash / timeout: forward unchanged (fail-safe)
+   */
+  private async runCommandOperator(
+    op: CommandOperatorConfig,
+    body: string,
+  ): Promise<string[] | null> {
+    const timeoutMs = op.timeoutMs ?? 30_000;
+
+    let proc: ReturnType<typeof Bun.spawn>;
+    try {
+      proc = Bun.spawn(["sh", "-c", op.cmd], {
+        stdin: new Blob([body]),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+    } catch {
+      // Spawn failure — forward unchanged (fail-safe)
+      return [body];
+    }
+
+    const timeoutId = { ref: null as ReturnType<typeof setTimeout> | null };
+
+    const timeoutPromise = new Promise<"timeout">((resolve) => {
+      timeoutId.ref = setTimeout(() => resolve("timeout"), timeoutMs);
+    });
+
+    const exitPromise = (async () => {
+      const [stdout, , code] = await Promise.all([
+        new Response(proc.stdout).text(),
+        new Response(proc.stderr).text(),
+        proc.exited,
+      ]);
+      return { stdout, code };
+    })();
+
+    const result = await Promise.race([exitPromise, timeoutPromise]);
+
+    if (timeoutId.ref !== null) clearTimeout(timeoutId.ref);
+
+    if (result === "timeout") {
+      proc.kill();
+      // Timeout — forward unchanged (fail-safe)
+      return [body];
+    }
+
+    const { stdout, code } = result;
+
+    if (code !== 0) {
+      // Non-zero exit — drop
+      return null;
+    }
+
+    const lines = stdout
+      .split("\n")
+      .map((l) => l.trimEnd())
+      .filter(Boolean);
+    if (lines.length === 0) {
+      // No output — drop
+      return null;
+    }
+
+    return lines;
+  }
+
+  /** Write a message file to a directory. */
+  private async writeMessage(
+    dir: string,
+    body: string,
+    origin: string,
+    error?: boolean,
+  ): Promise<void> {
+    const ts = Date.now();
+    const id = crypto.randomUUID().replace(/-/g, "").slice(0, 16);
+    const msg: Message = {
+      v: 1,
+      id,
+      from: this.instanceName,
+      ts,
+      body,
+      origin,
+      ...(error ? { error: true } : {}),
+    };
+    const filename = `${ts}-${id}.msg`;
+    await atomicWrite(join(dir, filename), JSON.stringify(msg, null, 2));
+  }
+
+  private async setStatus(status: "running" | "idle"): Promise<void> {
+    await atomicWrite(this.statusFile, status);
+  }
+}

--- a/packages/runner/src/pipe-runner.ts
+++ b/packages/runner/src/pipe-runner.ts
@@ -229,8 +229,8 @@ export class PipeRunner {
 
     const exitPromise = (async () => {
       const [stdout, , code] = await Promise.all([
-        new Response(proc.stdout).text(),
-        new Response(proc.stderr).text(),
+        new Response(proc.stdout as ReadableStream<Uint8Array>).text(),
+        new Response(proc.stderr as ReadableStream<Uint8Array>).text(),
         proc.exited,
       ]);
       return { stdout, code };


### PR DESCRIPTION
Implements #75.

## What

Adds `PipeRunner` to `packages/runner` — the core class that drives a pipe instance.

## How it works

Polls `inbox/` via `InboxWatcher`, runs each message through the configured operator chain, writes intermediate results to `steps/N/` as full `Message` objects, and writes final output to `outbox/`.

**Drop:** command exits non-zero → chain short-circuits, message acknowledged, nothing to outbox.

**Failure:** unrecoverable error → failure reply (`error: true`) written to outbox, original to `.failed/`.

**Command operator:** spawns `sh -c cmd` with message body on stdin. Each stdout line = one output message (fan-out). Timeout (30s default) and spawn failure both forward unchanged — fail-safe per ADR-010.

**Origin:** extended with the claimed filename at each step, tracing the full pipeline path.

## Tests

12 tests covering: end-to-end flow, step writing, two-operator chain, drop on non-zero exit, drop on empty output, chain short-circuit, fan-out from multi-line output, origin propagation, status file, inbox lifecycle, sequential multi-message processing.

## Unblocks

#76 (command operator enhancements), #77 (stateful operators), #84 (loom.yml pipes section), #111, #112, #113, #114, #115, #117