### PR TITLE
refactor: share runtime id generation

### DIFF
--- a/packages/runtime/src/crash.ts
+++ b/packages/runtime/src/crash.ts
@@ -9,6 +9,7 @@
 import { mkdirSync, readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { atomicWriteSync } from "./atomic-write";
+import { generateId } from "./id";
 
 export interface CrashRecord {
   /** ISO 8601 timestamp of the crash. */
@@ -23,17 +24,13 @@ export interface CrashRecord {
   nextRestartAt: string | null;
 }
 
-function generateSuffix(): string {
-  return crypto.randomUUID().replace(/-/g, "").slice(0, 16);
-}
-
 /** Write a crash record to the agent's crashes/ directory. */
 export function writeCrashRecord(agentDir: string, record: CrashRecord): void {
   const crashesDir = join(agentDir, "crashes");
   mkdirSync(crashesDir, { recursive: true });
 
   const tsNs = BigInt(Date.now()) * 1_000_000n;
-  const filename = `${tsNs}-${generateSuffix()}.json`;
+  const filename = `${tsNs}-${generateId()}.json`;
   atomicWriteSync(join(crashesDir, filename), JSON.stringify(record, null, 2));
 }
 

--- a/packages/runtime/src/id.test.ts
+++ b/packages/runtime/src/id.test.ts
@@ -1,0 +1,9 @@
+import { expect, test } from "bun:test";
+import { generateId } from "./id";
+
+test("generateId returns a 16-character lowercase hex string", () => {
+  const id = generateId();
+
+  expect(id).toHaveLength(16);
+  expect(id).toMatch(/^[0-9a-f]{16}$/);
+});

--- a/packages/runtime/src/id.ts
+++ b/packages/runtime/src/id.ts
@@ -1,0 +1,6 @@
+/** @file Identifier helpers shared by runtime file writers. */
+
+/** Generate a 16-character lowercase hexadecimal identifier. */
+export function generateId(): string {
+  return crypto.randomUUID().replace(/-/g, "").slice(0, 16);
+}

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -2,6 +2,7 @@ export { type AgentEntry, AgentProcess, type AgentStatus } from "./agent-process
 export { atomicWrite, atomicWriteSync } from "./atomic-write";
 export { type CrashRecord, listCrashRecords, writeCrashRecord } from "./crash";
 export { loomHome } from "./env";
+export { generateId } from "./id";
 export { InboxWatcher, type InboxWatcherOptions } from "./inbox-watcher";
 export { AgentLogger, type LogEntry, type LogLevel } from "./logger";
 export {

--- a/packages/runtime/src/message.ts
+++ b/packages/runtime/src/message.ts
@@ -11,6 +11,7 @@
 import { exists, mkdir, readdir, rename } from "node:fs/promises";
 import { join } from "node:path";
 import { atomicWrite } from "./atomic-write";
+import { generateId } from "./id";
 
 const MESSAGE_VERSION = 1;
 
@@ -25,10 +26,6 @@ export interface Message {
   origin?: string;
   /** True when this message signals a processing failure. */
   error?: boolean;
-}
-
-function generateId(): string {
-  return crypto.randomUUID().replace(/-/g, "").slice(0, 16);
 }
 
 /** Write a message to an agent's inbox. */


### PR DESCRIPTION
## Summary
- add a shared runtime `generateId()` helper
- use it for message IDs and crash-record filename suffixes
- export the helper from the runtime package
- add focused coverage for the 16-character lowercase hex contract

Closes #61

## Validation
- temp-installed TypeScript/Bun types: `tsc -p packages/runtime/tsconfig.json --noEmit`
- temp-installed Biome: `biome check packages/runtime/src/id.ts packages/runtime/src/id.test.ts packages/runtime/src/message.ts packages/runtime/src/crash.ts packages/runtime/src/index.ts`
- `git diff --check`

## Note
- Bun is not installed in this local environment, so I could not run `bun test`; the added test follows the existing `bun:test` style and is covered by typecheck.